### PR TITLE
tccbin: copy some headers from mingw for sokol support

### DIFF
--- a/include/winapi/driverspecs.h
+++ b/include/winapi/driverspecs.h
@@ -1,0 +1,17 @@
+/*
+ * PROJECT:         ReactOS DDK
+ * COPYRIGHT:       This file is in the Public Domain.
+ * FILE:            driverspecs.h
+ * ABSTRACT:        This header stubs out Driver Verifier annotations to
+ *                  allow drivers using them to compile with our header set.
+ */
+
+/*
+ * Stubs
+ */
+#define __drv_dispatchType(x)
+#define __drv_dispatchType_other
+
+#define __drv_aliasesMem
+#define __drv_allocatesMem(kind)
+#define __drv_freesMem(kind)

--- a/include/winapi/sal.h
+++ b/include/winapi/sal.h
@@ -1,0 +1,242 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+
+#ifndef SAL_HXX
+#define SAL_HXX
+
+#ifdef __GNUC__
+#  define __inner_checkReturn __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+#  define __inner_checkReturn __declspec("SAL_checkReturn")
+#else
+#  define __inner_checkReturn
+#endif
+
+#define __checkReturn __inner_checkReturn
+
+/* Pointer parameters */
+#define _In_
+#define _Out_
+#define _Inout_
+#define _In_z_
+#define _Inout_z_
+#define _In_reads_(s)
+#define _In_reads_bytes_(s)
+#define _In_reads_z_(s)
+#define _In_reads_or_z_(s)
+#define _Out_writes_(s)
+#define _Out_writes_bytes_(s)
+#define _Out_writes_z_(s)
+#define _Inout_updates_(s)
+#define _Inout_updates_bytes_(s)
+#define _Inout_updates_z_(s)
+#define _Out_writes_to_(s,c)
+#define _Out_writes_bytes_to_(s, c)
+#define _Out_writes_all_(s)
+#define _Out_writes_bytes_all_(s)
+#define _Inout_updates_to_(s, c)
+#define _Inout_updates_bytes_to_(s, c)
+#define _Inout_updates_all_(s)
+#define _Inout_updates_bytes_all_(s)
+#define _In_reads_to_ptr_(p)
+#define _In_reads_to_ptr_z_(p)
+#define _Out_writes_to_ptr_(p)
+#define _Out_writes_to_ptr_z(p)
+
+/* Optional pointer parameters */
+#define __in_opt
+#define __out_opt
+#define __inout_opt
+#define _In_opt_
+#define _Out_opt_
+#define _Inout_opt_
+#define _In_opt_z_
+#define _Inout_opt_z_
+#define _In_reads_opt_(s)
+#define _In_reads_bytes_opt_(s)
+#define _In_reads_opt_z_(s)
+
+#define _Out_writes_opt_(s)
+#define _Out_writes_opt_z_(s)
+#define _Inout_updates_opt_(s)
+#define _Inout_updates_bytes_opt_(s)
+#define _Inout_updates_opt_z_(s)
+#define _Out_writes_to_opt_(s, c)
+#define _Out_writes_bytes_to_opt_(s, c)
+#define _Out_writes_all_opt_(s)
+#define _Out_writes_bytes_all_opt_(s)
+
+#define _Inout_updates_to_opt_(s, c)
+#define _Inout_updates_bytes_to_opt_(s, c)
+#define _Inout_updates_all_opt_(s)
+#define _Inout_updates_bytes_all_opt_(s)
+#define _In_reads_to_ptr_opt_(p)
+#define _In_reads_to_ptr_opt_z_(p)
+#define _Out_writes_to_ptr_opt_(p)
+#define _Out_writes_to_ptr_opt_z_(p)
+
+/* Output pointer parameters */
+#define _Outptr_
+#define _Outptr_opt_
+#define _Outptr_result_maybenull_
+#define _Outptr_opt_result_maybenull_
+#define _Outptr_result_z_
+#define _Outptr_opt_result_z_
+#define _Outptr_result_maybenull_z_
+#define _Outptr_opt_result_maybenull_z_
+#define _COM_Outptr_
+#define _COM_Outptr_opt_
+#define _COM_Outptr_result_maybenull_
+#define _COM_Outptr_opt_result_maybenull_
+#define _Outptr_result_buffer_(s)
+#define _Outptr_result_bytebuffer_(s)
+#define _Outptr_opt_result_buffer_(s)
+#define _Outptr_opt_result_bytebuffer_(s)
+#define _Outptr_result_buffer_to_(s, c)
+#define _Outptr_result_bytebuffer_to_(s, c)
+#define _Outptr_result_bytebuffer_maybenull_(s)
+#define _Outptr_opt_result_buffer_to_(s, c)
+#define _Outptr_opt_result_bytebuffer_to_(s, c)
+#define _Result_nullonfailure_
+#define _Result_zeroonfailure_
+#define _Outptr_result_nullonfailure_
+#define _Outptr_opt_result_nullonfailure_
+#define _Outref_result_nullonfailure_
+
+/* Output reference parameters */
+#define _Outref_
+#define _Outref_result_maybenull_
+#define _Outref_result_buffer_(s)
+#define _Outref_result_bytebuffer_(s)
+#define _Outref_result_buffer_to_(s, c)
+#define _Outref_result_bytebuffer_to_(s, c)
+#define _Outref_result_buffer_all_(s)
+#define _Outref_result_bytebuffer_all_(s)
+#define _Outref_result_buffer_maybenull_(s)
+#define _Outref_result_bytebuffer_maybenull_(s)
+#define _Outref_result_buffer_to_maybenull_(s, c)
+#define _Outref_result_bytebuffer_to_maybenull_(s, c)
+#define _Outref_result_buffer_all_maybenull_(s)
+#define _Outref_result_bytebuffer_all_maybenull_(s)
+
+/* Return values */
+#define _Ret_z_
+#define _Ret_writes_(s)
+#define _Ret_writes_bytes_(s)
+#define _Ret_writes_z_(s)
+#define _Ret_writes_bytes_to_(s, c)
+#define _Ret_writes_maybenull_(s)
+#define _Ret_writes_to_maybenull_(s, c)
+#define _Ret_writes_maybenull_z_(s)
+#define _Ret_maybenull_
+#define _Ret_maybenull_z_
+#define _Ret_null_
+#define _Ret_notnull_
+#define _Ret_writes_bytes_to_(s, c)
+#define _Ret_writes_bytes_maybenull_(s)
+#define _Ret_writes_bytes_to_maybenull_(s, c)
+
+/* Other common annotations */
+#define _In_range_(low, hi)
+#define _Out_range_(low, hi)
+#define _Ret_range_(low, hi)
+#define _Deref_in_range_(low, hi)
+#define _Deref_out_range_(low, hi)
+#define _Deref_inout_range_(low, hi)
+#define _Pre_equal_to_(expr)
+#define _Post_equal_to_(expr)
+#define _Struct_size_bytes_(size)
+
+/* Function annotations */
+#define _Called_from_function_class_(name)
+#define _Check_return_ __checkReturn
+#define _Function_class_(name)
+#define _Raises_SEH_exception_
+#define _Maybe_raises_SEH_exception_
+#define _Must_inspect_result_
+#define _Use_decl_annotations_
+
+/* Success/failure annotations */
+#define _Always_(anno_list)
+#define _On_failure_(anno_list)
+#define _Return_type_success_(expr)
+#define _Success_(expr)
+
+#define _Reserved_
+#define _Const_
+
+/* Buffer properties */
+#define _Readable_bytes_(s)
+#define _Readable_elements_(s)
+#define _Writable_bytes_(s)
+#define _Writable_elements_(s)
+#define _Null_terminated_
+#define _NullNull_terminated_
+#define _Pre_readable_size_(s)
+#define _Pre_writable_size_(s)
+#define _Pre_readable_byte_size_(s)
+#define _Pre_writable_byte_size_(s)
+#define _Post_readable_size_(s)
+#define _Post_writable_size_(s)
+#define _Post_readable_byte_size_(s)
+#define _Post_writable_byte_size_(s)
+
+/* Field properties */
+#define _Field_size_(s)
+#define _Field_size_full_(s)
+#define _Field_size_full_opt_(s)
+#define _Field_size_opt_(s)
+#define _Field_size_part_(s, c)
+#define _Field_size_part_opt_(s, c)
+#define _Field_size_bytes_(size)
+#define _Field_size_bytes_full_(size)
+#define _Field_size_bytes_full_opt_(s)
+#define _Field_size_bytes_opt_(s)
+#define _Field_size_bytes_part_(s, c)
+#define _Field_size_bytes_part_opt_(s, c)
+#define _Field_z_
+#define _Field_range_(min, max)
+
+/* Structural annotations */
+#define _At_(e, a)
+#define _At_buffer_(e, i, c, a)
+#define _Group_(a)
+#define _When_(e, a)
+
+/* printf/scanf annotations */
+#define _Printf_format_string_
+#define _Scanf_format_string_
+#define _Scanf_s_format_string_
+#define _Format_string_impl_(kind,where)
+#define _Printf_format_string_params_(x)
+#define _Scanf_format_string_params_(x)
+#define _Scanf_s_format_string_params_(x)
+
+/* Analysis */
+#define _Analysis_assume_(expr)
+#define _Analysis_assume_nullterminated_(expr)
+
+/* FIXME: __in macro conflicts with argument names in libstdc++. For this reason,
+ * we disable it for C++. This should be fixed in libstdc++ so we can uncomment
+ * it in fixed version here. */
+#if !defined(__cplusplus) || !defined(__GNUC__)
+#define __in
+#define __out
+#endif
+
+#define __in_bcount(size)
+#define __in_ecount(size)
+
+#define __out_bcount(size)
+#define __out_bcount_part(size, length)
+#define __out_ecount(size)
+
+#define __inout
+
+#define __deref_out_ecount(size)
+
+#endif
+

--- a/include/winapi/shellapi.h
+++ b/include/winapi/shellapi.h
@@ -1,0 +1,904 @@
+/**
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER within this package.
+ */
+#include <winapifamily.h>
+
+#ifndef _INC_SHELLAPI
+#define _INC_SHELLAPI
+
+#include <specstrings.h>
+
+#ifndef WINSHELLAPI
+#ifndef _SHELL32_
+#define WINSHELLAPI DECLSPEC_IMPORT
+#else
+#define WINSHELLAPI
+#endif
+#endif
+
+#ifndef SHSTDAPI
+#ifndef _SHELL32_
+#ifdef __cplusplus
+#define SHSTDAPI EXTERN_C DECLSPEC_IMPORT HRESULT STDAPICALLTYPE
+#define SHSTDAPI_(type) EXTERN_C DECLSPEC_IMPORT type STDAPICALLTYPE
+#else
+#define SHSTDAPI DECLSPEC_IMPORT HRESULT STDAPICALLTYPE
+#define SHSTDAPI_(type) DECLSPEC_IMPORT type STDAPICALLTYPE
+#endif
+#else
+#define SHSTDAPI STDAPI
+#define SHSTDAPI_(type) STDAPI_(type)
+#endif
+#endif
+
+#ifndef SHDOCAPI
+#ifndef _SHDOCVW_
+#ifdef __cplusplus
+#define SHDOCAPI EXTERN_C DECLSPEC_IMPORT HRESULT STDAPICALLTYPE
+#define SHDOCAPI_(type) EXTERN_C DECLSPEC_IMPORT type STDAPICALLTYPE
+#else
+#define SHDOCAPI DECLSPEC_IMPORT HRESULT STDAPICALLTYPE
+#define SHDOCAPI_(type) DECLSPEC_IMPORT type STDAPICALLTYPE
+#endif
+#else
+#define SHDOCAPI STDAPI
+#define SHDOCAPI_(type) STDAPI_(type)
+#endif
+#endif
+
+#ifndef _WIN64
+#include <pshpack1.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+  DECLARE_HANDLE (HDROP);
+
+#define DragQueryFile __MINGW_NAME_AW(DragQueryFile)
+#define ShellExecute __MINGW_NAME_AW(ShellExecute)
+#define FindExecutable __MINGW_NAME_AW(FindExecutable)
+#define ShellAbout __MINGW_NAME_AW(ShellAbout)
+#define ExtractAssociatedIcon __MINGW_NAME_AW(ExtractAssociatedIcon)
+#define ExtractAssociatedIconEx __MINGW_NAME_AW(ExtractAssociatedIconEx)
+#define ExtractIcon __MINGW_NAME_AW(ExtractIcon)
+
+  SHSTDAPI_(UINT) DragQueryFileA (HDROP hDrop, UINT iFile, LPSTR lpszFile, UINT cch);
+  SHSTDAPI_(UINT) DragQueryFileW (HDROP hDrop, UINT iFile, LPWSTR lpszFile, UINT cch);
+  SHSTDAPI_(WINBOOL) DragQueryPoint (HDROP hDrop, POINT *ppt);
+  SHSTDAPI_(void) DragFinish (HDROP hDrop);
+  SHSTDAPI_(void) DragAcceptFiles (HWND hWnd, WINBOOL fAccept);
+  SHSTDAPI_(HINSTANCE) ShellExecuteA (HWND hwnd, LPCSTR lpOperation, LPCSTR lpFile, LPCSTR lpParameters, LPCSTR lpDirectory, INT nShowCmd);
+  SHSTDAPI_(HINSTANCE) ShellExecuteW (HWND hwnd, LPCWSTR lpOperation, LPCWSTR lpFile, LPCWSTR lpParameters, LPCWSTR lpDirectory, INT nShowCmd);
+  SHSTDAPI_(HINSTANCE) FindExecutableA (LPCSTR lpFile, LPCSTR lpDirectory, LPSTR lpResult);
+  SHSTDAPI_(HINSTANCE) FindExecutableW (LPCWSTR lpFile, LPCWSTR lpDirectory, LPWSTR lpResult);
+  SHSTDAPI_(LPWSTR *) CommandLineToArgvW (LPCWSTR lpCmdLine, int *pNumArgs);
+  SHSTDAPI_(INT) ShellAboutA (HWND hWnd, LPCSTR szApp, LPCSTR szOtherStuff, HICON hIcon);
+  SHSTDAPI_(INT) ShellAboutW (HWND hWnd, LPCWSTR szApp, LPCWSTR szOtherStuff, HICON hIcon);
+  SHSTDAPI_(HICON) DuplicateIcon (HINSTANCE hInst, HICON hIcon);
+  SHSTDAPI_(HICON) ExtractAssociatedIconA (HINSTANCE hInst, LPSTR pszIconPath, WORD *piIcon);
+  SHSTDAPI_(HICON) ExtractAssociatedIconW (HINSTANCE hInst, LPWSTR pszIconPath, WORD *piIcon);
+  SHSTDAPI_(HICON) ExtractAssociatedIconExA (HINSTANCE hInst, LPSTR pszIconPath, WORD *piIconIndex, WORD *piIconId);
+  SHSTDAPI_(HICON) ExtractAssociatedIconExW (HINSTANCE hInst, LPWSTR pszIconPath, WORD *piIconIndex, WORD *piIconId);
+  SHSTDAPI_(HICON) ExtractIconA (HINSTANCE hInst, LPCSTR pszExeFileName, UINT nIconIndex);
+  SHSTDAPI_(HICON) ExtractIconW (HINSTANCE hInst, LPCWSTR pszExeFileName, UINT nIconIndex);
+
+  typedef struct _DRAGINFOA {
+    UINT uSize;
+    POINT pt;
+    WINBOOL fNC;
+    LPSTR lpFileList;
+    DWORD grfKeyState;
+  } DRAGINFOA,*LPDRAGINFOA;
+
+  typedef struct _DRAGINFOW {
+    UINT uSize;
+    POINT pt;
+    WINBOOL fNC;
+    LPWSTR lpFileList;
+    DWORD grfKeyState;
+  } DRAGINFOW,*LPDRAGINFOW;
+
+  DRAGINFO;
+  LPDRAGINFO;
+
+#define ABM_NEW 0x00000000
+#define ABM_REMOVE 0x00000001
+#define ABM_QUERYPOS 0x00000002
+#define ABM_SETPOS 0x00000003
+#define ABM_GETSTATE 0x00000004
+#define ABM_GETTASKBARPOS 0x00000005
+#define ABM_ACTIVATE 0x00000006
+#define ABM_GETAUTOHIDEBAR 0x00000007
+#define ABM_SETAUTOHIDEBAR 0x00000008
+
+#define ABM_WINDOWPOSCHANGED 0x0000009
+#define ABM_SETSTATE 0x0000000a
+#if NTDDI_VERSION >= 0x06020000
+#define ABM_GETAUTOHIDEBAREX 0x0000000b
+#define ABM_SETAUTOHIDEBAREX 0x0000000c
+#endif
+
+#define ABN_STATECHANGE 0x0000000
+#define ABN_POSCHANGED 0x0000001
+#define ABN_FULLSCREENAPP 0x0000002
+#define ABN_WINDOWARRANGE 0x0000003
+
+#define ABS_AUTOHIDE 0x0000001
+#define ABS_ALWAYSONTOP 0x0000002
+
+#define ABE_LEFT 0
+#define ABE_TOP 1
+#define ABE_RIGHT 2
+#define ABE_BOTTOM 3
+
+  typedef struct _AppBarData {
+    DWORD cbSize;
+    HWND hWnd;
+    UINT uCallbackMessage;
+    UINT uEdge;
+    RECT rc;
+    LPARAM lParam;
+  } APPBARDATA,*PAPPBARDATA;
+
+  SHSTDAPI_(UINT_PTR) SHAppBarMessage (DWORD dwMessage, PAPPBARDATA pData);
+  SHSTDAPI_(DWORD) DoEnvironmentSubstA (LPSTR pszSrc, UINT cchSrc);
+  SHSTDAPI_(DWORD) DoEnvironmentSubstW (LPWSTR pszSrc, UINT cchSrc);
+  SHSTDAPI_(UINT) ExtractIconExA (LPCSTR lpszFile, int nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIcons);
+  SHSTDAPI_(UINT) ExtractIconExW (LPCWSTR lpszFile, int nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIcons);
+
+#define DoEnvironmentSubst __MINGW_NAME_AW(DoEnvironmentSubst)
+#define ExtractIconEx __MINGW_NAME_AW(ExtractIconEx)
+
+#define EIRESID(x) (-1 * (int)(x))
+
+#define FO_MOVE 0x1
+#define FO_COPY 0x2
+#define FO_DELETE 0x3
+#define FO_RENAME 0x4
+
+#define FOF_MULTIDESTFILES 0x1
+#define FOF_CONFIRMMOUSE 0x2
+#define FOF_SILENT 0x4
+#define FOF_RENAMEONCOLLISION 0x8
+#define FOF_NOCONFIRMATION 0x10
+#define FOF_WANTMAPPINGHANDLE 0x20
+#define FOF_ALLOWUNDO 0x40
+#define FOF_FILESONLY 0x80
+#define FOF_SIMPLEPROGRESS 0x100
+#define FOF_NOCONFIRMMKDIR 0x200
+#define FOF_NOERRORUI 0x400
+#define FOF_NOCOPYSECURITYATTRIBS 0x800
+#define FOF_NORECURSION 0x1000
+#define FOF_NO_CONNECTED_ELEMENTS 0x2000
+#define FOF_WANTNUKEWARNING 0x4000
+#define FOF_NORECURSEREPARSE 0x8000
+
+#define FOF_NO_UI (FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR)
+
+  typedef WORD FILEOP_FLAGS;
+
+#define PO_DELETE 0x0013
+#define PO_RENAME 0x0014
+#define PO_PORTCHANGE 0x0020
+
+#define PO_REN_PORT 0x0034
+
+  typedef WORD PRINTEROP_FLAGS;
+
+  typedef struct _SHFILEOPSTRUCTA {
+    HWND hwnd;
+    UINT wFunc;
+    LPCSTR pFrom;
+    LPCSTR pTo;
+    FILEOP_FLAGS fFlags;
+    WINBOOL fAnyOperationsAborted;
+    LPVOID hNameMappings;
+    PCSTR lpszProgressTitle;
+  } SHFILEOPSTRUCTA,*LPSHFILEOPSTRUCTA;
+
+  typedef struct _SHFILEOPSTRUCTW {
+    HWND hwnd;
+    UINT wFunc;
+    LPCWSTR pFrom;
+    LPCWSTR pTo;
+    FILEOP_FLAGS fFlags;
+    WINBOOL fAnyOperationsAborted;
+    LPVOID hNameMappings;
+    PCWSTR lpszProgressTitle;
+  } SHFILEOPSTRUCTW,*LPSHFILEOPSTRUCTW;
+
+  SHFILEOPSTRUCT;
+  LPSHFILEOPSTRUCT;
+
+  SHSTDAPI_(int) SHFileOperationA (LPSHFILEOPSTRUCTA lpFileOp);
+  SHSTDAPI_(int) SHFileOperationW (LPSHFILEOPSTRUCTW lpFileOp);
+
+#define SHFileOperation __MINGW_NAME_AW(SHFileOperation)
+
+  SHSTDAPI_(void) SHFreeNameMappings (HANDLE hNameMappings);
+
+  typedef struct _SHNAMEMAPPINGA {
+    LPSTR pszOldPath;
+    LPSTR pszNewPath;
+    int cchOldPath;
+    int cchNewPath;
+  } SHNAMEMAPPINGA,*LPSHNAMEMAPPINGA;
+
+  typedef struct _SHNAMEMAPPINGW {
+    LPWSTR pszOldPath;
+    LPWSTR pszNewPath;
+    int cchOldPath;
+    int cchNewPath;
+  } SHNAMEMAPPINGW,*LPSHNAMEMAPPINGW;
+
+
+  SHNAMEMAPPING;
+  LPSHNAMEMAPPING;
+
+#define SE_ERR_FNF 2
+#define SE_ERR_PNF 3
+#define SE_ERR_ACCESSDENIED 5
+#define SE_ERR_OOM 8
+#define SE_ERR_DLLNOTFOUND 32
+
+#define SE_ERR_SHARE 26
+#define SE_ERR_ASSOCINCOMPLETE 27
+#define SE_ERR_DDETIMEOUT 28
+#define SE_ERR_DDEFAIL 29
+#define SE_ERR_DDEBUSY 30
+#define SE_ERR_NOASSOC 31
+
+#define SEE_MASK_DEFAULT 0x0
+#define SEE_MASK_CLASSNAME 0x1
+#define SEE_MASK_CLASSKEY 0x3
+
+#define SEE_MASK_IDLIST 0x4
+#define SEE_MASK_INVOKEIDLIST 0xc
+#if NTDDI_VERSION < 0x06000000
+#define SEE_MASK_ICON 0x10
+#endif
+#define SEE_MASK_HOTKEY 0x20
+#define SEE_MASK_NOCLOSEPROCESS 0x40
+#define SEE_MASK_CONNECTNETDRV 0x80
+#define SEE_MASK_NOASYNC 0x100
+#define SEE_MASK_FLAG_DDEWAIT SEE_MASK_NOASYNC
+#define SEE_MASK_DOENVSUBST 0x200
+#define SEE_MASK_FLAG_NO_UI 0x400
+#define SEE_MASK_UNICODE 0x4000
+#define SEE_MASK_NO_CONSOLE 0x8000
+#define SEE_MASK_ASYNCOK 0x100000
+#define SEE_MASK_HMONITOR 0x200000
+#define SEE_MASK_NOZONECHECKS 0x800000
+#define SEE_MASK_NOQUERYCLASSSTORE 0x1000000
+#define SEE_MASK_WAITFORINPUTIDLE 0x2000000
+#define SEE_MASK_FLAG_LOG_USAGE 0x4000000
+#if NTDDI_VERSION >= 0x06020000
+#define SEE_MASK_FLAG_HINST_IS_SITE 0x8000000
+#endif
+
+#ifndef DUMMYUNIONNAME
+#ifdef NONAMELESSUNION
+#define DUMMYUNIONNAME u
+#define DUMMYUNIONNAME2 u2
+#define DUMMYUNIONNAME3 u3
+#define DUMMYUNIONNAME4 u4
+#define DUMMYUNIONNAME5 u5
+#else
+#define DUMMYUNIONNAME
+#define DUMMYUNIONNAME2
+#define DUMMYUNIONNAME3
+#define DUMMYUNIONNAME4
+#define DUMMYUNIONNAME5
+#endif
+#endif
+
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+
+  typedef struct _SHELLEXECUTEINFOA {
+    DWORD cbSize;
+    ULONG fMask;
+    HWND hwnd;
+    LPCSTR lpVerb;
+    LPCSTR lpFile;
+    LPCSTR lpParameters;
+    LPCSTR lpDirectory;
+    int nShow;
+    HINSTANCE hInstApp;
+    void *lpIDList;
+    LPCSTR lpClass;
+    HKEY hkeyClass;
+    DWORD dwHotKey;
+    __C89_NAMELESS union {
+      HANDLE hIcon;
+      HANDLE hMonitor;
+    } DUMMYUNIONNAME;
+    HANDLE hProcess;
+  } SHELLEXECUTEINFOA,*LPSHELLEXECUTEINFOA;
+
+  typedef struct _SHELLEXECUTEINFOW {
+    DWORD cbSize;
+    ULONG fMask;
+    HWND hwnd;
+    LPCWSTR lpVerb;
+    LPCWSTR lpFile;
+    LPCWSTR lpParameters;
+    LPCWSTR lpDirectory;
+    int nShow;
+    HINSTANCE hInstApp;
+    void *lpIDList;
+    LPCWSTR lpClass;
+    HKEY hkeyClass;
+    DWORD dwHotKey;
+    __C89_NAMELESS union {
+      HANDLE hIcon;
+      HANDLE hMonitor;
+    } DUMMYUNIONNAME;
+    HANDLE hProcess;
+  } SHELLEXECUTEINFOW,*LPSHELLEXECUTEINFOW;
+
+  SHELLEXECUTEINFO;
+  LPSHELLEXECUTEINFO;
+
+  SHSTDAPI_(WINBOOL) ShellExecuteExA (SHELLEXECUTEINFOA *pExecInfo);
+  SHSTDAPI_(WINBOOL) ShellExecuteExW (SHELLEXECUTEINFOW *pExecInfo);
+
+#define ShellExecuteEx __MINGW_NAME_AW(ShellExecuteEx)
+
+  typedef struct _SHCREATEPROCESSINFOW {
+    DWORD cbSize;
+    ULONG fMask;
+    HWND hwnd;
+    LPCWSTR pszFile;
+    LPCWSTR pszParameters;
+    LPCWSTR pszCurrentDirectory;
+    HANDLE hUserToken;
+    LPSECURITY_ATTRIBUTES lpProcessAttributes;
+    LPSECURITY_ATTRIBUTES lpThreadAttributes;
+    WINBOOL bInheritHandles;
+    DWORD dwCreationFlags;
+    LPSTARTUPINFOW lpStartupInfo;
+    LPPROCESS_INFORMATION lpProcessInformation;
+  } SHCREATEPROCESSINFOW,*PSHCREATEPROCESSINFOW;
+
+  SHSTDAPI_(WINBOOL) SHCreateProcessAsUserW (PSHCREATEPROCESSINFOW pscpi);
+
+#if NTDDI_VERSION >= 0x06000000
+  SHSTDAPI SHEvaluateSystemCommandTemplate (PCWSTR pszCmdTemplate, PWSTR *ppszApplication, PWSTR *ppszCommandLine, PWSTR *ppszParameters);
+
+  typedef enum ASSOCCLASS {
+    ASSOCCLASS_SHELL_KEY = 0,
+    ASSOCCLASS_PROGID_KEY,
+    ASSOCCLASS_PROGID_STR,
+    ASSOCCLASS_CLSID_KEY,
+    ASSOCCLASS_CLSID_STR,
+    ASSOCCLASS_APP_KEY,
+    ASSOCCLASS_APP_STR,
+    ASSOCCLASS_SYSTEM_STR,
+    ASSOCCLASS_FOLDER,
+    ASSOCCLASS_STAR,
+#if NTDDI_VERSION >= 0x06020000
+    ASSOCCLASS_FIXED_PROGID_STR,
+    ASSOCCLASS_PROTOCOL_STR,
+#endif
+  } ASSOCCLASS;
+
+  typedef struct ASSOCIATIONELEMENT {
+    ASSOCCLASS ac;
+    HKEY hkClass;
+    PCWSTR pszClass;
+  } ASSOCIATIONELEMENT;
+
+  SHSTDAPI AssocCreateForClasses (const ASSOCIATIONELEMENT *rgClasses, ULONG cClasses, REFIID riid, void **ppv);
+#endif
+
+  typedef struct _SHQUERYRBINFO {
+    DWORD cbSize;
+    __MINGW_EXTENSION __int64 i64Size;
+    __MINGW_EXTENSION __int64 i64NumItems;
+  } SHQUERYRBINFO,*LPSHQUERYRBINFO;
+
+#define SHERB_NOCONFIRMATION 0x00000001
+#define SHERB_NOPROGRESSUI 0x00000002
+#define SHERB_NOSOUND 0x00000004
+
+  SHSTDAPI SHQueryRecycleBinA (LPCSTR pszRootPath, LPSHQUERYRBINFO pSHQueryRBInfo);
+  SHSTDAPI SHQueryRecycleBinW (LPCWSTR pszRootPath, LPSHQUERYRBINFO pSHQueryRBInfo);
+
+#define SHQueryRecycleBin __MINGW_NAME_AW(SHQueryRecycleBin)
+
+  SHSTDAPI SHEmptyRecycleBinA (HWND hwnd, LPCSTR pszRootPath, DWORD dwFlags);
+  SHSTDAPI SHEmptyRecycleBinW (HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags);
+
+#define SHEmptyRecycleBin __MINGW_NAME_AW(SHEmptyRecycleBin)
+
+#if NTDDI_VERSION >= 0x06000000
+  typedef enum {
+    QUNS_NOT_PRESENT = 1,
+    QUNS_BUSY = 2,
+    QUNS_RUNNING_D3D_FULL_SCREEN = 3,
+    QUNS_PRESENTATION_MODE = 4,
+    QUNS_ACCEPTS_NOTIFICATIONS = 5
+#if NTDDI_VERSION >= 0x06010000
+    , QUNS_QUIET_TIME = 6
+#endif
+#if NTDDI_VERSION >= 0x06020000
+    , QUNS_APP = 7
+#endif
+  } QUERY_USER_NOTIFICATION_STATE;
+
+  SHSTDAPI SHQueryUserNotificationState (QUERY_USER_NOTIFICATION_STATE *pquns);
+#endif
+
+#if NTDDI_VERSION >= 0x06010000
+  SHSTDAPI SHGetPropertyStoreForWindow (HWND hwnd, REFIID riid, void **ppv);
+#endif
+
+#endif /* WINAPI_PARTITION_DESKTOP.  */
+
+  typedef struct _NOTIFYICONDATAA {
+    DWORD cbSize;
+    HWND hWnd;
+    UINT uID;
+    UINT uFlags;
+    UINT uCallbackMessage;
+    HICON hIcon;
+    CHAR szTip[128];
+    DWORD dwState;
+    DWORD dwStateMask;
+    CHAR szInfo[256];
+    __C89_NAMELESS union {
+      UINT uTimeout;
+      UINT uVersion;
+    } DUMMYUNIONNAME;
+    CHAR szInfoTitle[64];
+    DWORD dwInfoFlags;
+    GUID guidItem;
+#if NTDDI_VERSION >= 0x06000000
+    HICON hBalloonIcon;
+#endif
+  } NOTIFYICONDATAA,*PNOTIFYICONDATAA;
+
+  typedef struct _NOTIFYICONDATAW {
+    DWORD cbSize;
+    HWND hWnd;
+    UINT uID;
+    UINT uFlags;
+    UINT uCallbackMessage;
+    HICON hIcon;
+    WCHAR szTip[128];
+    DWORD dwState;
+    DWORD dwStateMask;
+    WCHAR szInfo[256];
+    __C89_NAMELESS union {
+      UINT uTimeout;
+      UINT uVersion;
+    } DUMMYUNIONNAME;
+    WCHAR szInfoTitle[64];
+    DWORD dwInfoFlags;
+    GUID guidItem;
+#if NTDDI_VERSION >= 0x06000000
+    HICON hBalloonIcon;
+#endif
+  } NOTIFYICONDATAW,*PNOTIFYICONDATAW;
+
+  NOTIFYICONDATA;
+  PNOTIFYICONDATA;
+
+#define NOTIFYICONDATAA_V1_SIZE FIELD_OFFSET (NOTIFYICONDATAA, szTip[64])
+#define NOTIFYICONDATAW_V1_SIZE FIELD_OFFSET (NOTIFYICONDATAW, szTip[64])
+#define NOTIFYICONDATAA_V2_SIZE FIELD_OFFSET (NOTIFYICONDATAA, guidItem)
+#define NOTIFYICONDATAW_V2_SIZE FIELD_OFFSET (NOTIFYICONDATAW, guidItem)
+#define NOTIFYICONDATAA_V3_SIZE FIELD_OFFSET (NOTIFYICONDATAA, hBalloonIcon)
+#define NOTIFYICONDATAW_V3_SIZE FIELD_OFFSET (NOTIFYICONDATAW, hBalloonIcon)
+
+#define NOTIFYICONDATA_V1_SIZE __MINGW_NAME_AW_EXT(NOTIFYICONDATA,_V1_SIZE)
+#define NOTIFYICONDATA_V2_SIZE __MINGW_NAME_AW_EXT(NOTIFYICONDATA,_V2_SIZE)
+#define NOTIFYICONDATA_V3_SIZE __MINGW_NAME_AW_EXT(NOTIFYICONDATA,_V3_SIZE)
+
+#define NIN_SELECT (WM_USER + 0)
+#define NINF_KEY 0x1
+#define NIN_KEYSELECT (NIN_SELECT | NINF_KEY)
+
+#define NIN_BALLOONSHOW (WM_USER + 2)
+#define NIN_BALLOONHIDE (WM_USER + 3)
+#define NIN_BALLOONTIMEOUT (WM_USER + 4)
+#define NIN_BALLOONUSERCLICK (WM_USER + 5)
+#if NTDDI_VERSION >= 0x06000000
+#define NIN_POPUPOPEN (WM_USER + 6)
+#define NIN_POPUPCLOSE (WM_USER + 7)
+#endif
+
+#define NIM_ADD 0x00000000
+#define NIM_MODIFY 0x00000001
+#define NIM_DELETE 0x00000002
+#define NIM_SETFOCUS 0x00000003
+#define NIM_SETVERSION 0x00000004
+
+#define NOTIFYICON_VERSION 3
+#if NTDDI_VERSION >= 0x06000000
+#define NOTIFYICON_VERSION_4 4
+#endif
+
+#define NIF_MESSAGE 0x00000001
+#define NIF_ICON 0x00000002
+#define NIF_TIP 0x00000004
+#define NIF_STATE 0x00000008
+#define NIF_INFO 0x00000010
+#if _WIN32_IE >= 0x600
+#define NIF_GUID 0x00000020
+#endif
+#if NTDDI_VERSION >= 0x06000000
+#define NIF_REALTIME 0x00000040
+#define NIF_SHOWTIP 0x00000080
+#endif
+
+#define NIS_HIDDEN 0x00000001
+#define NIS_SHAREDICON 0x00000002
+
+#define NIIF_NONE 0x00000000
+#define NIIF_INFO 0x00000001
+#define NIIF_WARNING 0x00000002
+#define NIIF_ERROR 0x00000003
+#define NIIF_USER 0x00000004
+#define NIIF_ICON_MASK 0x0000000f
+#define NIIF_NOSOUND 0x00000010
+#if NTDDI_VERSION >= 0x06000000
+#define NIIF_LARGE_ICON 0x00000020
+#endif
+#if NTDDI_VERSION >= 0x06010000
+#define NIIF_RESPECT_QUIET_TIME 0x00000080
+#endif
+
+  typedef struct _NOTIFYICONIDENTIFIER {
+    DWORD cbSize;
+    HWND hWnd;
+    UINT uID;
+    GUID guidItem;
+  } NOTIFYICONIDENTIFIER,*PNOTIFYICONIDENTIFIER;
+
+  SHSTDAPI_(WINBOOL) Shell_NotifyIconA (DWORD dwMessage, PNOTIFYICONDATAA lpData);
+  SHSTDAPI_(WINBOOL) Shell_NotifyIconW (DWORD dwMessage, PNOTIFYICONDATAW lpData);
+
+#define Shell_NotifyIcon __MINGW_NAME_AW(Shell_NotifyIcon)
+
+#if NTDDI_VERSION >= 0x06010000
+  SHSTDAPI Shell_NotifyIconGetRect (const NOTIFYICONIDENTIFIER *identifier, RECT *iconLocation);
+#endif
+
+#ifndef SHFILEINFO_DEFINED
+#define SHFILEINFO_DEFINED
+
+  typedef struct _SHFILEINFOA {
+    HICON hIcon;
+    int iIcon;
+    DWORD dwAttributes;
+    CHAR szDisplayName[MAX_PATH];
+    CHAR szTypeName[80];
+  } SHFILEINFOA;
+
+  typedef struct _SHFILEINFOW {
+    HICON hIcon;
+    int iIcon;
+    DWORD dwAttributes;
+    WCHAR szDisplayName[MAX_PATH];
+    WCHAR szTypeName[80];
+  } SHFILEINFOW;
+
+  SHFILEINFO;
+#endif
+
+#define SHGFI_ICON 0x000000100
+#define SHGFI_DISPLAYNAME 0x000000200
+#define SHGFI_TYPENAME 0x000000400
+#define SHGFI_ATTRIBUTES 0x000000800
+#define SHGFI_ICONLOCATION 0x000001000
+#define SHGFI_EXETYPE 0x000002000
+#define SHGFI_SYSICONINDEX 0x000004000
+#define SHGFI_LINKOVERLAY 0x000008000
+#define SHGFI_SELECTED 0x000010000
+#define SHGFI_ATTR_SPECIFIED 0x000020000
+
+#define SHGFI_LARGEICON 0x000000000
+#define SHGFI_SMALLICON 0x000000001
+#define SHGFI_OPENICON 0x000000002
+#define SHGFI_SHELLICONSIZE 0x000000004
+#define SHGFI_PIDL 0x000000008
+#define SHGFI_USEFILEATTRIBUTES 0x000000010
+
+#define SHGFI_ADDOVERLAYS 0x000000020
+#define SHGFI_OVERLAYINDEX 0x000000040
+
+  SHSTDAPI_(DWORD_PTR) SHGetFileInfoA (LPCSTR pszPath, DWORD dwFileAttributes, SHFILEINFOA *psfi, UINT cbFileInfo, UINT uFlags);
+  SHSTDAPI_(DWORD_PTR) SHGetFileInfoW (LPCWSTR pszPath, DWORD dwFileAttributes, SHFILEINFOW *psfi, UINT cbFileInfo, UINT uFlags);
+
+#define SHGetFileInfo __MINGW_NAME_AW(SHGetFileInfo)
+
+#if NTDDI_VERSION >= 0x06000000
+  typedef struct _SHSTOCKICONINFO {
+    DWORD cbSize;
+    HICON hIcon;
+    int iSysImageIndex;
+    int iIcon;
+    WCHAR szPath[MAX_PATH];
+  } SHSTOCKICONINFO;
+
+#define SHGSI_ICONLOCATION 0
+#define SHGSI_ICON SHGFI_ICON
+#define SHGSI_SYSICONINDEX SHGFI_SYSICONINDEX
+#define SHGSI_LINKOVERLAY SHGFI_LINKOVERLAY
+#define SHGSI_SELECTED SHGFI_SELECTED
+#define SHGSI_LARGEICON SHGFI_LARGEICON
+#define SHGSI_SMALLICON SHGFI_SMALLICON
+#define SHGSI_SHELLICONSIZE SHGFI_SHELLICONSIZE
+
+  typedef enum SHSTOCKICONID {
+    SIID_DOCNOASSOC = 0,
+    SIID_DOCASSOC = 1,
+    SIID_APPLICATION = 2,
+    SIID_FOLDER = 3,
+    SIID_FOLDEROPEN = 4,
+    SIID_DRIVE525 = 5,
+    SIID_DRIVE35 = 6,
+    SIID_DRIVEREMOVE = 7,
+    SIID_DRIVEFIXED = 8,
+    SIID_DRIVENET = 9,
+    SIID_DRIVENETDISABLED = 10,
+    SIID_DRIVECD = 11,
+    SIID_DRIVERAM = 12,
+    SIID_WORLD = 13,
+    SIID_SERVER = 15,
+    SIID_PRINTER = 16,
+    SIID_MYNETWORK = 17,
+    SIID_FIND = 22,
+    SIID_HELP = 23,
+    SIID_SHARE = 28,
+    SIID_LINK = 29,
+    SIID_SLOWFILE = 30,
+    SIID_RECYCLER = 31,
+    SIID_RECYCLERFULL = 32,
+    SIID_MEDIACDAUDIO = 40,
+    SIID_LOCK = 47,
+    SIID_AUTOLIST = 49,
+    SIID_PRINTERNET = 50,
+    SIID_SERVERSHARE = 51,
+    SIID_PRINTERFAX = 52,
+    SIID_PRINTERFAXNET = 53,
+    SIID_PRINTERFILE = 54,
+    SIID_STACK = 55,
+    SIID_MEDIASVCD = 56,
+    SIID_STUFFEDFOLDER = 57,
+    SIID_DRIVEUNKNOWN = 58,
+    SIID_DRIVEDVD = 59,
+    SIID_MEDIADVD = 60,
+    SIID_MEDIADVDRAM = 61,
+    SIID_MEDIADVDRW = 62,
+    SIID_MEDIADVDR = 63,
+    SIID_MEDIADVDROM = 64,
+    SIID_MEDIACDAUDIOPLUS = 65,
+    SIID_MEDIACDRW = 66,
+    SIID_MEDIACDR = 67,
+    SIID_MEDIACDBURN = 68,
+    SIID_MEDIABLANKCD = 69,
+    SIID_MEDIACDROM = 70,
+    SIID_AUDIOFILES = 71,
+    SIID_IMAGEFILES = 72,
+    SIID_VIDEOFILES = 73,
+    SIID_MIXEDFILES = 74,
+    SIID_FOLDERBACK = 75,
+    SIID_FOLDERFRONT = 76,
+    SIID_SHIELD = 77,
+    SIID_WARNING = 78,
+    SIID_INFO = 79,
+    SIID_ERROR = 80,
+    SIID_KEY = 81,
+    SIID_SOFTWARE = 82,
+    SIID_RENAME = 83,
+    SIID_DELETE = 84,
+    SIID_MEDIAAUDIODVD = 85,
+    SIID_MEDIAMOVIEDVD = 86,
+    SIID_MEDIAENHANCEDCD = 87,
+    SIID_MEDIAENHANCEDDVD = 88,
+    SIID_MEDIAHDDVD = 89,
+    SIID_MEDIABLURAY = 90,
+    SIID_MEDIAVCD = 91,
+    SIID_MEDIADVDPLUSR = 92,
+    SIID_MEDIADVDPLUSRW = 93,
+    SIID_DESKTOPPC = 94,
+    SIID_MOBILEPC = 95,
+    SIID_USERS = 96,
+    SIID_MEDIASMARTMEDIA = 97,
+    SIID_MEDIACOMPACTFLASH = 98,
+    SIID_DEVICECELLPHONE = 99,
+    SIID_DEVICECAMERA = 100,
+    SIID_DEVICEVIDEOCAMERA = 101,
+    SIID_DEVICEAUDIOPLAYER = 102,
+    SIID_NETWORKCONNECT = 103,
+    SIID_INTERNET = 104,
+    SIID_ZIPFILE = 105,
+    SIID_SETTINGS = 106,
+
+    SIID_DRIVEHDDVD = 132,
+    SIID_DRIVEBD = 133,
+    SIID_MEDIAHDDVDROM = 134,
+    SIID_MEDIAHDDVDR = 135,
+    SIID_MEDIAHDDVDRAM = 136,
+    SIID_MEDIABDROM = 137,
+    SIID_MEDIABDR = 138,
+    SIID_MEDIABDRE = 139,
+    SIID_CLUSTEREDDRIVE = 140,
+
+    SIID_MAX_ICONS = 175
+  } SHSTOCKICONID;
+
+#define SIID_INVALID ((SHSTOCKICONID)-1)
+
+  SHSTDAPI SHGetStockIconInfo (SHSTOCKICONID siid, UINT uFlags, SHSTOCKICONINFO *psii);
+#endif
+
+#define SHGetDiskFreeSpace SHGetDiskFreeSpaceEx
+
+  SHSTDAPI_(WINBOOL) SHGetDiskFreeSpaceExA (LPCSTR pszDirectoryName, ULARGE_INTEGER *pulFreeBytesAvailableToCaller, ULARGE_INTEGER *pulTotalNumberOfBytes, ULARGE_INTEGER *pulTotalNumberOfFreeBytes);
+  SHSTDAPI_(WINBOOL) SHGetDiskFreeSpaceExW (LPCWSTR pszDirectoryName, ULARGE_INTEGER *pulFreeBytesAvailableToCaller, ULARGE_INTEGER *pulTotalNumberOfBytes, ULARGE_INTEGER *pulTotalNumberOfFreeBytes);
+  SHSTDAPI_(WINBOOL) SHGetNewLinkInfoA (LPCSTR pszLinkTo, LPCSTR pszDir, LPSTR pszName, WINBOOL *pfMustCopy, UINT uFlags);
+  SHSTDAPI_(WINBOOL) SHGetNewLinkInfoW (LPCWSTR pszLinkTo, LPCWSTR pszDir, LPWSTR pszName, WINBOOL *pfMustCopy, UINT uFlags);
+
+#define SHGetDiskFreeSpaceEx __MINGW_NAME_AW(SHGetDiskFreeSpaceEx)
+#define SHGetNewLinkInfo __MINGW_NAME_AW(SHGetNewLinkInfo)
+
+#define SHGNLI_PIDL 0x000000001
+#define SHGNLI_PREFIXNAME 0x000000002
+#define SHGNLI_NOUNIQUE 0x000000004
+#define SHGNLI_NOLNK 0x000000008
+#if _WIN32_IE >= 0x0600
+#define SHGNLI_NOLOCNAME 0x000000010
+#endif
+#if NTDDI_VERSION >= 0x06010000
+#define SHGNLI_USEURLEXT 0x000000020
+#endif
+
+#define PRINTACTION_OPEN 0
+#define PRINTACTION_PROPERTIES 1
+#define PRINTACTION_NETINSTALL 2
+#define PRINTACTION_NETINSTALLLINK 3
+#define PRINTACTION_TESTPAGE 4
+#define PRINTACTION_OPENNETPRN 5
+#define PRINTACTION_DOCUMENTDEFAULTS 6
+#define PRINTACTION_SERVERPROPERTIES 7
+
+  SHSTDAPI_(WINBOOL) SHInvokePrinterCommandA (HWND hwnd, UINT uAction, LPCSTR lpBuf1, LPCSTR lpBuf2, WINBOOL fModal);
+  SHSTDAPI_(WINBOOL) SHInvokePrinterCommandW (HWND hwnd, UINT uAction, LPCWSTR lpBuf1, LPCWSTR lpBuf2, WINBOOL fModal);
+
+#define SHInvokePrinterCommand __MINGW_NAME_AW(SHInvokePrinterCommand)
+
+#if NTDDI_VERSION >= 0x06000000
+  typedef struct _OPEN_PRINTER_PROPS_INFOA {
+    DWORD dwSize;
+    LPSTR pszSheetName;
+    UINT uSheetIndex;
+    DWORD dwFlags;
+    WINBOOL bModal;
+  } OPEN_PRINTER_PROPS_INFOA,*POPEN_PRINTER_PROPS_INFOA;
+
+  typedef struct _OPEN_PRINTER_PROPS_INFOW {
+    DWORD dwSize;
+    LPWSTR pszSheetName;
+    UINT uSheetIndex;
+    DWORD dwFlags;
+    WINBOOL bModal;
+  } OPEN_PRINTER_PROPS_INFOW,*POPEN_PRINTER_PROPS_INFOW;
+
+  OPEN_PRINTER_PROPS_INFO;
+  POPEN_PRINTER_PROPS_INFO;
+#define PRINT_PROP_FORCE_NAME 0x01
+#endif
+
+  SHSTDAPI SHLoadNonloadedIconOverlayIdentifiers (void);
+  SHSTDAPI SHIsFileAvailableOffline (PCWSTR pwszPath, DWORD *pdwStatus);
+
+#define OFFLINE_STATUS_LOCAL 0x0001
+#define OFFLINE_STATUS_REMOTE 0x0002
+#define OFFLINE_STATUS_INCOMPLETE 0x0004
+
+  SHSTDAPI SHSetLocalizedName (PCWSTR pszPath, PCWSTR pszResModule, int idsRes);
+
+#if NTDDI_VERSION >= 0x06000000
+  SHSTDAPI SHRemoveLocalizedName (PCWSTR pszPath);
+  SHSTDAPI SHGetLocalizedName (PCWSTR pszPath, PWSTR pszResModule, UINT cch, int *pidsRes);
+#endif
+
+#ifndef _SHLWAPI_
+#define LWSTDAPIV_(type) EXTERN_C DECLSPEC_IMPORT type STDAPIVCALLTYPE
+#else
+#define LWSTDAPIV_(type) STDAPIV_ (type)
+#endif
+
+  LWSTDAPIV_ (int) ShellMessageBoxA (HINSTANCE hAppInst, HWND hWnd, LPCSTR lpcText, LPCSTR lpcTitle, UINT fuStyle,...);
+  LWSTDAPIV_ (int) ShellMessageBoxW (HINSTANCE hAppInst, HWND hWnd, LPCWSTR lpcText, LPCWSTR lpcTitle, UINT fuStyle,...);
+
+#define ShellMessageBox __MINGW_NAME_AW(ShellMessageBox)
+
+  SHSTDAPI_(WINBOOL) IsLFNDriveA (LPCSTR pszPath);
+  SHSTDAPI_(WINBOOL) IsLFNDriveW (LPCWSTR pszPath);
+
+#define IsLFNDrive __MINGW_NAME_AW(IsLFNDrive)
+
+#if _WIN32_IE >= 0x0600
+  STDAPI SHEnumerateUnreadMailAccountsA (HKEY hKeyUser, DWORD dwIndex, LPSTR pszMailAddress, int cchMailAddress);
+  STDAPI SHEnumerateUnreadMailAccountsW (HKEY hKeyUser, DWORD dwIndex, LPWSTR pszMailAddress, int cchMailAddress);
+  STDAPI SHGetUnreadMailCountA (HKEY hKeyUser, LPCSTR pszMailAddress, DWORD *pdwCount, FILETIME *pFileTime, LPSTR pszShellExecuteCommand, int cchShellExecuteCommand);
+  STDAPI SHGetUnreadMailCountW (HKEY hKeyUser, LPCWSTR pszMailAddress, DWORD *pdwCount, FILETIME *pFileTime, LPWSTR pszShellExecuteCommand, int cchShellExecuteCommand);
+  STDAPI SHSetUnreadMailCountA (LPCSTR pszMailAddress, DWORD dwCount, LPCSTR pszShellExecuteCommand);
+  STDAPI SHSetUnreadMailCountW (LPCWSTR pszMailAddress, DWORD dwCount, LPCWSTR pszShellExecuteCommand);
+
+#define SHEnumerateUnreadMailAccounts __MINGW_NAME_AW(SHEnumerateUnreadMailAccounts)
+#define SHGetUnreadMailCount __MINGW_NAME_AW(SHGetUnreadMailCount)
+#define SHSetUnreadMailCount __MINGW_NAME_AW(SHSetUnreadMailCount)
+
+#endif
+#if _WIN32_IE >= 0x0601
+  STDAPI_ (WINBOOL) SHTestTokenMembership (HANDLE hToken, ULONG ulRID);
+#endif
+
+#if _WIN32_IE >= 0x0600
+  SHSTDAPI SHGetImageList (int iImageList, REFIID riid, void **ppvObj);
+
+#define SHIL_LARGE 0
+#define SHIL_SMALL 1
+#define SHIL_EXTRALARGE 2
+#define SHIL_SYSSMALL 3
+#if NTDDI_VERSION >= 0x06000000
+#define SHIL_JUMBO 4
+#define SHIL_LAST SHIL_JUMBO
+#else
+#define SHIL_LAST SHIL_SYSSMALL
+#endif
+
+  typedef HRESULT (STDMETHODCALLTYPE *PFNCANSHAREFOLDERW) (PCWSTR pszPath);
+  typedef HRESULT (STDMETHODCALLTYPE *PFNSHOWSHAREFOLDERUIW) (HWND hwndParent, PCWSTR pszPath);
+
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifndef _WIN64
+#include <poppack.h>
+#endif
+
+#if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+#if NTDDI_VERSION >= 0x06000000
+
+#define WC_NETADDRESS L"msctls_netaddress"
+
+SHSTDAPI_(WINBOOL) InitNetworkAddressControl (void);
+
+#define NCM_GETADDRESS (WM_USER+1)
+#define NetAddr_GetAddress(hwnd, pv) (HRESULT)SNDMSG (hwnd, NCM_GETADDRESS, 0,(LPARAM)pv)
+
+typedef struct tagNC_ADDRESS {
+  struct NET_ADDRESS_INFO_ *pAddrInfo;
+  USHORT PortNumber;
+  BYTE PrefixLength;
+} NC_ADDRESS,*PNC_ADDRESS;
+
+#define NCM_SETALLOWTYPE (WM_USER+2)
+#define NetAddr_SetAllowType(hwnd, addrMask) (HRESULT)SNDMSG (hwnd, NCM_SETALLOWTYPE,(WPARAM)addrMask, 0)
+
+#define NCM_GETALLOWTYPE (WM_USER+3)
+#define NetAddr_GetAllowType(hwnd) (DWORD)SNDMSG (hwnd, NCM_GETALLOWTYPE, 0, 0)
+
+#define NCM_DISPLAYERRORTIP (WM_USER+4)
+#define NetAddr_DisplayErrorTip(hwnd) (HRESULT)SNDMSG (hwnd, NCM_DISPLAYERRORTIP, 0, 0)
+#endif
+
+#if NTDDI_VERSION >= 0x06000000
+STDAPI SHGetDriveMedia (PCWSTR pszDrive, DWORD *pdwMediaContent);
+#endif
+#endif
+#endif

--- a/include/winapi/specstrings.h
+++ b/include/winapi/specstrings.h
@@ -1,0 +1,338 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+
+#ifndef SPECSTRINGS_H
+#define SPECSTRINGS_H
+
+#define __specstrings
+
+#include <sal.h>
+
+#ifdef __cplusplus
+#ifndef __nothrow
+#define __nothrow __declspec(nothrow)
+#endif
+extern "C" {
+#else
+#ifndef __nothrow
+#define __nothrow
+#endif
+#endif
+
+#define SAL__deref_in
+#define SAL__deref_in_ecount(size)
+#define SAL__deref_in_bcount(size)
+
+#define SAL__deref_in_opt
+#define SAL__deref_in_ecount_opt(size)
+#define SAL__deref_in_bcount_opt(size)
+
+#define SAL__deref_opt_in
+#define SAL__deref_opt_in_ecount(size)
+#define SAL__deref_opt_in_bcount(size)
+
+#define SAL__deref_opt_in_opt
+#define SAL__deref_opt_in_ecount_opt(size)
+#define SAL__deref_opt_in_bcount_opt(size)
+
+#define SAL__out_awcount(expr,size)
+#define SAL__in_awcount(expr,size)
+
+/* Renamed __null to SAL__null for avoiding private keyword conflicts between
+   gcc and MS world.  */
+#define SAL__null
+#define SAL__notnull
+#define SAL__maybenull
+#define SAL__readonly
+#define SAL__notreadonly
+#define SAL__maybereadonly
+#define SAL__valid
+#define SAL__notvalid
+#define SAL__maybevalid
+#define SAL__readableTo(extent)
+#define SAL__elem_readableTo(size)
+#define SAL__byte_readableTo(size)
+#define SAL__writableTo(size)
+#define SAL__elem_writableTo(size)
+#define SAL__byte_writableTo(size)
+#define SAL__deref
+#define SAL__pre
+#define SAL__post
+#define SAL__precond(expr)
+#define SAL__postcond(expr)
+#define SAL__exceptthat
+#define SAL__execeptthat
+#define SAL__inner_success(expr)
+#define SAL__inner_checkReturn
+#define SAL__inner_typefix(ctype)
+#define SAL__inner_override
+#define SAL__inner_callback
+#define SAL__inner_blocksOn(resource)
+#define SAL__inner_fallthrough_dec
+#define SAL__inner_fallthrough
+#define __refparam
+#define SAL__inner_control_entrypoint(category)
+#define SAL__inner_data_entrypoint(category)
+
+#define SAL__ecount(size)
+#define SAL__bcount(size)
+
+#define SAL__in
+#define SAL__in_opt
+#define SAL__in_nz
+#define SAL__in_nz_opt
+#define SAL__in_z
+#define SAL__in_z_opt
+#define SAL__in_ecount(size)
+#define SAL__in_ecount_nz(size)
+#define SAL__in_ecount_z(size)
+#define SAL__in_bcount(size)
+#define SAL__in_bcount_z(size)
+#define SAL__in_bcount_nz(size)
+#define SAL__in_ecount_opt(size)
+#define SAL__in_bcount_opt(size)
+#define SAL__in_ecount_z_opt(size)
+#define SAL__in_bcount_z_opt(size)
+#define SAL__in_ecount_nz_opt(size)
+#define SAL__in_bcount_nz_opt(size)
+
+#define SAL__out
+#define SAL__out_ecount(size)
+#define SAL__out_z
+#define SAL__out_nz
+#define SAL__out_nz_opt
+#define SAL__out_z_opt
+#define SAL__out_ecount_part(size,length)
+#define SAL__out_ecount_full(size)
+#define SAL__out_ecount_nz(size)
+#define SAL__out_ecount_z(size)
+#define SAL__out_ecount_part_z(size,length)
+#define SAL__out_ecount_full_z(size)
+#define SAL__out_bcount(size)
+#define SAL__out_bcount_part(size,length)
+#define SAL__out_bcount_full(size)
+#define SAL__out_bcount_z(size)
+#define SAL__out_bcount_part_z(size,length)
+#define SAL__out_bcount_full_z(size)
+#define SAL__out_bcount_nz(size)
+
+#define SAL__inout
+#define SAL__inout_ecount(size)
+#define SAL__inout_bcount(size)
+#define SAL__inout_ecount_part(size,length)
+#define SAL__inout_bcount_part(size,length)
+#define SAL__inout_ecount_full(size)
+#define SAL__inout_bcount_full(size)
+#define SAL__inout_z
+#define SAL__inout_ecount_z(size)
+#define SAL__inout_bcount_z(size)
+#define SAL__inout_nz
+#define SAL__inout_ecount_nz(size)
+#define SAL__inout_bcount_nz(size)
+#define SAL__ecount_opt(size)
+#define SAL__bcount_opt(size)
+#define SAL__out_opt
+#define SAL__out_ecount_opt(size)
+#define SAL__out_bcount_opt(size)
+#define SAL__out_ecount_part_opt(size,length)
+#define SAL__out_bcount_part_opt(size,length)
+#define SAL__out_ecount_full_opt(size)
+#define SAL__out_bcount_full_opt(size)
+#define SAL__out_ecount_z_opt(size)
+#define SAL__out_bcount_z_opt(size)
+#define SAL__out_ecount_part_z_opt(size,length)
+#define SAL__out_bcount_part_z_opt(size,length)
+#define SAL__out_ecount_full_z_opt(size)
+#define SAL__out_bcount_full_z_opt(size)
+#define SAL__out_ecount_nz_opt(size)
+#define SAL__out_bcount_nz_opt(size)
+#define SAL__inout_opt
+#define SAL__inout_ecount_opt(size)
+#define SAL__inout_bcount_opt(size)
+#define SAL__inout_ecount_part_opt(size,length)
+#define SAL__inout_bcount_part_opt(size,length)
+#define SAL__inout_ecount_full_opt(size)
+#define SAL__inout_bcount_full_opt(size)
+#define SAL__inout_z_opt
+#define SAL__inout_ecount_z_opt(size)
+#define SAL__inout_bcount_z_opt(size)
+#define SAL__inout_nz_opt
+#define SAL__inout_ecount_nz_opt(size)
+#define SAL__inout_bcount_nz_opt(size)
+#define SAL__deref_ecount(size)
+#define SAL__deref_bcount(size)
+#define SAL__deref_out
+#define SAL__deref_out_ecount(size)
+#define SAL__deref_out_bcount(size)
+#define SAL__deref_out_ecount_part(size,length)
+#define SAL__deref_out_bcount_part(size,length)
+#define SAL__deref_out_ecount_full(size)
+#define SAL__deref_out_bcount_full(size)
+#define SAL__deref_out_z
+#define SAL__deref_out_ecount_z(size)
+#define SAL__deref_out_bcount_z(size)
+#define SAL__deref_out_nz
+#define SAL__deref_out_ecount_nz(size)
+#define SAL__deref_out_bcount_nz(size)
+#define SAL__deref_inout
+#define SAL__deref_inout_ecount(size)
+#define SAL__deref_inout_bcount(size)
+#define SAL__deref_inout_ecount_part(size,length)
+#define SAL__deref_inout_bcount_part(size,length)
+#define SAL__deref_inout_ecount_full(size)
+#define SAL__deref_inout_bcount_full(size)
+#define SAL__deref_inout_z
+#define SAL__deref_inout_ecount_z(size)
+#define SAL__deref_inout_bcount_z(size)
+#define SAL__deref_inout_nz
+#define SAL__deref_inout_ecount_nz(size)
+#define SAL__deref_inout_bcount_nz(size)
+#define SAL__deref_ecount_opt(size)
+#define SAL__deref_bcount_opt(size)
+#define SAL__deref_out_opt
+#define SAL__deref_out_ecount_opt(size)
+#define SAL__deref_out_bcount_opt(size)
+#define SAL__deref_out_ecount_part_opt(size,length)
+#define SAL__deref_out_bcount_part_opt(size,length)
+#define SAL__deref_out_ecount_full_opt(size)
+#define SAL__deref_out_bcount_full_opt(size)
+#define SAL__deref_out_z_opt
+#define SAL__deref_out_ecount_z_opt(size)
+#define SAL__deref_out_bcount_z_opt(size)
+#define SAL__deref_out_nz_opt
+#define SAL__deref_out_ecount_nz_opt(size)
+#define SAL__deref_out_bcount_nz_opt(size)
+#define SAL__deref_inout_opt
+#define SAL__deref_inout_ecount_opt(size)
+#define SAL__deref_inout_bcount_opt(size)
+#define SAL__deref_inout_ecount_part_opt(size,length)
+#define SAL__deref_inout_bcount_part_opt(size,length)
+#define SAL__deref_inout_ecount_full_opt(size)
+#define SAL__deref_inout_bcount_full_opt(size)
+#define SAL__deref_inout_z_opt
+#define SAL__deref_inout_ecount_z_opt(size)
+#define SAL__deref_inout_bcount_z_opt(size)
+#define SAL__deref_inout_nz_opt
+#define SAL__deref_inout_ecount_nz_opt(size)
+#define SAL__deref_inout_bcount_nz_opt(size)
+#define SAL__deref_opt_ecount(size)
+#define SAL__deref_opt_bcount(size)
+#define SAL__deref_opt_out
+#define SAL__deref_opt_out_z
+#define SAL__deref_opt_out_ecount(size)
+#define SAL__deref_opt_out_bcount(size)
+#define SAL__deref_opt_out_ecount_part(size,length)
+#define SAL__deref_opt_out_bcount_part(size,length)
+#define SAL__deref_opt_out_ecount_full(size)
+#define SAL__deref_opt_out_bcount_full(size)
+#define SAL__deref_opt_inout
+#define SAL__deref_opt_inout_ecount(size)
+#define SAL__deref_opt_inout_bcount(size)
+#define SAL__deref_opt_inout_ecount_part(size,length)
+#define SAL__deref_opt_inout_bcount_part(size,length)
+#define SAL__deref_opt_inout_ecount_full(size)
+#define SAL__deref_opt_inout_bcount_full(size)
+#define SAL__deref_opt_inout_z
+#define SAL__deref_opt_inout_ecount_z(size)
+#define SAL__deref_opt_inout_bcount_z(size)
+#define SAL__deref_opt_inout_nz
+#define SAL__deref_opt_inout_ecount_nz(size)
+#define SAL__deref_opt_inout_bcount_nz(size)
+#define SAL__deref_opt_ecount_opt(size)
+#define SAL__deref_opt_bcount_opt(size)
+#define SAL__deref_opt_out_opt
+#define SAL__deref_opt_out_ecount_opt(size)
+#define SAL__deref_opt_out_bcount_opt(size)
+#define SAL__deref_opt_out_ecount_part_opt(size,length)
+#define SAL__deref_opt_out_bcount_part_opt(size,length)
+#define SAL__deref_opt_out_ecount_full_opt(size)
+#define SAL__deref_opt_out_bcount_full_opt(size)
+#define SAL__deref_opt_out_z_opt
+#define SAL__deref_opt_out_ecount_z_opt(size)
+#define SAL__deref_opt_out_bcount_z_opt(size)
+#define SAL__deref_opt_out_nz_opt
+#define SAL__deref_opt_out_ecount_nz_opt(size)
+#define SAL__deref_opt_out_bcount_nz_opt(size)
+#define SAL__deref_opt_inout_opt
+#define SAL__deref_opt_inout_ecount_opt(size)
+#define SAL__deref_opt_inout_bcount_opt(size)
+#define SAL__deref_opt_inout_ecount_part_opt(size,length)
+#define SAL__deref_opt_inout_bcount_part_opt(size,length)
+#define SAL__deref_opt_inout_ecount_full_opt(size)
+#define SAL__deref_opt_inout_bcount_full_opt(size)
+#define SAL__deref_opt_inout_z_opt
+#define SAL__deref_opt_inout_ecount_z_opt(size)
+#define SAL__deref_opt_inout_bcount_z_opt(size)
+#define SAL__deref_opt_inout_nz_opt
+#define SAL__deref_opt_inout_ecount_nz_opt(size)
+#define SAL__deref_opt_inout_bcount_nz_opt(size)
+
+#define SAL__success(expr)
+#define SAL__nullterminated
+#define SAL__nullnullterminated
+#define SAL__reserved
+#define SAL__checkReturn
+#define SAL__typefix(ctype)
+#define SAL__override
+#define SAL__callback
+#define SAL__format_string
+#define SAL__blocksOn(resource)
+#define SAL__control_entrypoint(category)
+#define SAL__data_entrypoint(category)
+
+#define __encoded_pointer
+
+#ifndef __fallthrough
+#define __fallthrough
+#endif
+
+#ifndef __analysis_assume
+#define __analysis_assume(expr)
+#endif
+
+#ifndef __CLR_OR_THIS_CALL
+#define __CLR_OR_THIS_CALL
+#endif
+
+#ifndef __CLRCALL_OR_CDECL
+#define __CLRCALL_OR_CDECL __cdecl
+#endif
+
+#ifndef __STDC_WANT_SECURE_LIB__
+#define __STDC_WANT_SECURE_LIB__ 0
+#endif
+
+#ifndef _CRT_SECURE_NO_DEPRECATE
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
+#ifndef RC_INVOKED
+#ifndef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
+#define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 0
+#endif
+#ifndef _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT
+#define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT 0
+#endif
+#ifndef _CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES
+#define _CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES 0
+#endif
+#endif
+
+#ifndef DECLSPEC_ADDRSAFE
+#if (_MSC_VER >= 1200) && (defined(_M_ALPHA) || defined(_M_AXP64))
+#define DECLSPEC_ADDRSAFE  __declspec(address_safe)
+#else
+#define DECLSPEC_ADDRSAFE
+#endif
+#endif /* DECLSPEC_ADDRSAFE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <driverspecs.h>
+
+#endif

--- a/include/winapi/winapifamily.h
+++ b/include/winapi/winapifamily.h
@@ -1,0 +1,24 @@
+/**
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER within this package.
+ */
+
+#ifndef _INC_WINAPIFAMILY
+#define _INC_WINAPIFAMILY
+
+#define WINAPI_PARTITION_DESKTOP 0x1
+#define WINAPI_PARTITION_APP     0x2    
+
+#define WINAPI_FAMILY_APP WINAPI_PARTITION_APP
+#define WINAPI_FAMILY_DESKTOP_APP (WINAPI_PARTITION_DESKTOP \
+				   | WINAPI_PARTITION_APP)    
+
+/* WINAPI_FAMILY can be either desktop + App, or App.  */
+#ifndef WINAPI_FAMILY
+#define WINAPI_FAMILY WINAPI_FAMILY_DESKTOP_APP
+#endif
+
+#define WINAPI_FAMILY_PARTITION(v) ((WINAPI_FAMILY & v) == v)
+#define WINAPI_FAMILY_ONE_PARTITION(vset, v) ((WINAPI_FAMILY & vset) == v)
+
+#endif 

--- a/include/winapi/windowsx.h
+++ b/include/winapi/windowsx.h
@@ -1,0 +1,790 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+#ifndef _INC_WINDOWSX
+#define _INC_WINDOWSX
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef SNDMSG
+#ifdef __cplusplus
+#define SNDMSG ::SendMessage
+#else
+#define SNDMSG SendMessage
+#endif
+#endif
+
+#define GetInstanceModule(hInstance) (HMODULE)(hInstance)
+#define GlobalPtrHandle(lp) ((HGLOBAL)GlobalHandle(lp))
+#define GlobalLockPtr(lp) ((WINBOOL)GlobalLock(GlobalPtrHandle(lp)))
+#define GlobalUnlockPtr(lp) GlobalUnlock(GlobalPtrHandle(lp))
+#define GlobalAllocPtr(flags,cb) (GlobalLock(GlobalAlloc((flags),(cb))))
+#define GlobalReAllocPtr(lp,cbNew,flags) (GlobalUnlockPtr(lp),GlobalLock(GlobalReAlloc(GlobalPtrHandle(lp) ,(cbNew),(flags))))
+#define GlobalFreePtr(lp) (GlobalUnlockPtr(lp),(WINBOOL)(ULONG_PTR)GlobalFree(GlobalPtrHandle(lp)))
+#define DeletePen(hpen) DeleteObject((HGDIOBJ)(HPEN)(hpen))
+#define SelectPen(hdc,hpen) ((HPEN)SelectObject((hdc),(HGDIOBJ)(HPEN)(hpen)))
+#define GetStockPen(i) ((HPEN)GetStockObject(i))
+#define DeleteBrush(hbr) DeleteObject((HGDIOBJ)(HBRUSH)(hbr))
+#define SelectBrush(hdc,hbr) ((HBRUSH)SelectObject((hdc),(HGDIOBJ)(HBRUSH)(hbr)))
+#define GetStockBrush(i) ((HBRUSH)GetStockObject(i))
+#define DeleteRgn(hrgn) DeleteObject((HGDIOBJ)(HRGN)(hrgn))
+#define CopyRgn(hrgnDst,hrgnSrc) CombineRgn(hrgnDst,hrgnSrc,0,RGN_COPY)
+#define IntersectRgn(hrgnResult,hrgnA,hrgnB) CombineRgn(hrgnResult,hrgnA,hrgnB,RGN_AND)
+#define SubtractRgn(hrgnResult,hrgnA,hrgnB) CombineRgn(hrgnResult,hrgnA,hrgnB,RGN_DIFF)
+#define UnionRgn(hrgnResult,hrgnA,hrgnB) CombineRgn(hrgnResult,hrgnA,hrgnB,RGN_OR)
+#define XorRgn(hrgnResult,hrgnA,hrgnB) CombineRgn(hrgnResult,hrgnA,hrgnB,RGN_XOR)
+#define DeletePalette(hpal) DeleteObject((HGDIOBJ)(HPALETTE)(hpal))
+#define DeleteFont(hfont) DeleteObject((HGDIOBJ)(HFONT)(hfont))
+#define SelectFont(hdc,hfont) ((HFONT)SelectObject((hdc),(HGDIOBJ)(HFONT)(hfont)))
+#define GetStockFont(i) ((HFONT)GetStockObject(i))
+#define DeleteBitmap(hbm) DeleteObject((HGDIOBJ)(HBITMAP)(hbm))
+#define SelectBitmap(hdc,hbm) ((HBITMAP)SelectObject((hdc),(HGDIOBJ)(HBITMAP)(hbm)))
+#define InsetRect(lprc,dx,dy) InflateRect((lprc),-(dx),-(dy))
+#define GetWindowInstance(hwnd) ((HMODULE)GetWindowLongPtr(hwnd,GWLP_HINSTANCE))
+#define GetWindowStyle(hwnd) ((DWORD)GetWindowLong(hwnd,GWL_STYLE))
+#define GetWindowExStyle(hwnd) ((DWORD)GetWindowLong(hwnd,GWL_EXSTYLE))
+#define GetWindowOwner(hwnd) GetWindow(hwnd,GW_OWNER)
+#define GetFirstChild(hwnd) GetTopWindow(hwnd)
+#define GetFirstSibling(hwnd) GetWindow(hwnd,GW_HWNDFIRST)
+#define GetLastSibling(hwnd) GetWindow(hwnd,GW_HWNDLAST)
+#define GetNextSibling(hwnd) GetWindow(hwnd,GW_HWNDNEXT)
+#define GetPrevSibling(hwnd) GetWindow(hwnd,GW_HWNDPREV)
+#define GetWindowID(hwnd) GetDlgCtrlID(hwnd)
+#define SetWindowRedraw(hwnd,fRedraw) ((void)SNDMSG(hwnd,WM_SETREDRAW,(WPARAM)(WINBOOL)(fRedraw),(LPARAM)0))
+#define SubclassWindow(hwnd,lpfn) ((WNDPROC)SetWindowLongPtr((hwnd),GWLP_WNDPROC,(LPARAM)(WNDPROC)(lpfn)))
+#define IsMinimized(hwnd) IsIconic(hwnd)
+#define IsMaximized(hwnd) IsZoomed(hwnd)
+#define IsRestored(hwnd) (!(GetWindowStyle(hwnd) & (WS_MINIMIZE | WS_MAXIMIZE)))
+#define SetWindowFont(hwnd,hfont,fRedraw) FORWARD_WM_SETFONT((hwnd),(hfont),(fRedraw),SNDMSG)
+#define GetWindowFont(hwnd) FORWARD_WM_GETFONT((hwnd),SNDMSG)
+#define MapWindowRect(hwndFrom,hwndTo,lprc) MapWindowPoints((hwndFrom),(hwndTo),(POINT *)(lprc),2)
+#define IsLButtonDown() (GetKeyState(VK_LBUTTON) < 0)
+#define IsRButtonDown() (GetKeyState(VK_RBUTTON) < 0)
+#define IsMButtonDown() (GetKeyState(VK_MBUTTON) < 0)
+#define SubclassDialog(hwndDlg,lpfn) (SetWindowLongPtr(hwndDlg,DWLP_DLGPROC,(LPARAM)(lpfn)))
+#define SetDlgMsgResult(hwnd,msg,result) (((msg)==WM_CTLCOLORMSGBOX || (msg)==WM_CTLCOLOREDIT || (msg)==WM_CTLCOLORLISTBOX || (msg)==WM_CTLCOLORBTN || (msg)==WM_CTLCOLORDLG || (msg)==WM_CTLCOLORSCROLLBAR || (msg)==WM_CTLCOLORSTATIC || (msg)==WM_COMPAREITEM || (msg)==WM_VKEYTOITEM || (msg)==WM_CHARTOITEM || (msg)==WM_QUERYDRAGICON || (msg)==WM_INITDIALOG) ? (WINBOOL)(result) : (SetWindowLongPtr((hwnd),DWLP_MSGRESULT,(LPARAM)(LRESULT)(result)),TRUE))
+#define DefDlgProcEx(hwnd,msg,wParam,lParam,pfRecursion) (*(pfRecursion) = TRUE,DefDlgProc(hwnd,msg,wParam,lParam))
+#define CheckDefDlgRecursion(pfRecursion) if (*(pfRecursion)) { *(pfRecursion) = FALSE; return FALSE; }
+#define HANDLE_MSG(hwnd,message,fn) case (message): return HANDLE_##message((hwnd),(wParam),(lParam),(fn))
+#define HANDLE_WM_COMPACTING(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_COMPACTING(hwnd,compactRatio,fn) (void)(fn)((hwnd),WM_COMPACTING,(WPARAM)(UINT)(compactRatio),(LPARAM)0)
+#define HANDLE_WM_WININICHANGE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(LPCTSTR)(lParam)),(LRESULT)0)
+#define FORWARD_WM_WININICHANGE(hwnd,lpszSectionName,fn) (void)(fn)((hwnd),WM_WININICHANGE,(WPARAM)0,(LPARAM)(LPCTSTR)(lpszSectionName))
+#define HANDLE_WM_SYSCOLORCHANGE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_SYSCOLORCHANGE(hwnd,fn) (void)(fn)((hwnd),WM_SYSCOLORCHANGE,(WPARAM)0,(LPARAM)0)
+#define HANDLE_WM_QUERYNEWPALETTE(hwnd,wParam,lParam,fn) MAKELRESULT((WINBOOL)(fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_QUERYNEWPALETTE(hwnd,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_QUERYNEWPALETTE,(WPARAM)0,(LPARAM)0)
+#define HANDLE_WM_PALETTEISCHANGING(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_PALETTEISCHANGING(hwnd,hwndPaletteChange,fn) (void)(fn)((hwnd),WM_PALETTEISCHANGING,(WPARAM)(HWND)(hwndPaletteChange),(LPARAM)0)
+#define HANDLE_WM_PALETTECHANGED(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_PALETTECHANGED(hwnd,hwndPaletteChange,fn) (void)(fn)((hwnd),WM_PALETTECHANGED,(WPARAM)(HWND)(hwndPaletteChange),(LPARAM)0)
+#define HANDLE_WM_FONTCHANGE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_FONTCHANGE(hwnd,fn) (void)(fn)((hwnd),WM_FONTCHANGE,(WPARAM)0,(LPARAM)0)
+#define HANDLE_WM_SPOOLERSTATUS(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),(int)(short)LOWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SPOOLERSTATUS(hwnd,status,cJobInQueue,fn) (void)(fn)((hwnd),WM_SPOOLERSTATUS,(WPARAM)(status),MAKELPARAM((cJobInQueue),0))
+#define HANDLE_WM_DEVMODECHANGE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(LPCTSTR)(lParam)),(LRESULT)0)
+#define FORWARD_WM_DEVMODECHANGE(hwnd,lpszDeviceName,fn) (void)(fn)((hwnd),WM_DEVMODECHANGE,(WPARAM)0,(LPARAM)(LPCTSTR)(lpszDeviceName))
+#define HANDLE_WM_TIMECHANGE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_TIMECHANGE(hwnd,fn) (void)(fn)((hwnd),WM_TIMECHANGE,(WPARAM)0,(LPARAM)0)
+#define HANDLE_WM_POWER(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(wParam)),(LRESULT)0)
+#define FORWARD_WM_POWER(hwnd,code,fn) (void)(fn)((hwnd),WM_POWER,(WPARAM)(int)(code),(LPARAM)0)
+#define HANDLE_WM_QUERYENDSESSION(hwnd,wParam,lParam,fn) MAKELRESULT((WINBOOL)(fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_QUERYENDSESSION(hwnd,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_QUERYENDSESSION,(WPARAM)0,(LPARAM)0)
+#define HANDLE_WM_ENDSESSION(hwnd,wParam,lParam,fn) ((fn)((hwnd),(WINBOOL)(wParam)),(LRESULT)0)
+#define FORWARD_WM_ENDSESSION(hwnd,fEnding,fn) (void)(fn)((hwnd),WM_ENDSESSION,(WPARAM)(WINBOOL)(fEnding),(LPARAM)0)
+#define HANDLE_WM_QUIT(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(wParam)),(LRESULT)0)
+#define FORWARD_WM_QUIT(hwnd,exitCode,fn) (void)(fn)((hwnd),WM_QUIT,(WPARAM)(exitCode),(LPARAM)0)
+#define HANDLE_WM_SYSTEMERROR(hwnd,wParam,lParam,fn) (LRESULT)0
+#define FORWARD_WM_SYSTEMERROR(hwnd,errCode,fn) (LRESULT)0
+
+#define HANDLE_WM_CREATE(hwnd,wParam,lParam,fn) (LRESULT)((fn)((hwnd),(LPCREATESTRUCT)(lParam)) ? 0 : -1)
+#define FORWARD_WM_CREATE(hwnd,lpCreateStruct,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_CREATE,(WPARAM)0,(LPARAM)(LPCREATESTRUCT)(lpCreateStruct))
+
+#define HANDLE_WM_NCCREATE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(LPCREATESTRUCT)(lParam))
+#define FORWARD_WM_NCCREATE(hwnd,lpCreateStruct,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_NCCREATE,(WPARAM)0,(LPARAM)(LPCREATESTRUCT)(lpCreateStruct))
+
+#define HANDLE_WM_DESTROY(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_DESTROY(hwnd,fn) (void)(fn)((hwnd),WM_DESTROY,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_NCDESTROY(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_NCDESTROY(hwnd,fn) (void)(fn)((hwnd),WM_NCDESTROY,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_SHOWWINDOW(hwnd,wParam,lParam,fn) ((fn)((hwnd),(WINBOOL)(wParam),(UINT)(lParam)),(LRESULT)0)
+#define FORWARD_WM_SHOWWINDOW(hwnd,fShow,status,fn) (void)(fn)((hwnd),WM_SHOWWINDOW,(WPARAM)(WINBOOL)(fShow),(LPARAM)(UINT)(status))
+
+#define HANDLE_WM_SETREDRAW(hwnd,wParam,lParam,fn) ((fn)((hwnd),(WINBOOL)(wParam)),(LRESULT)0)
+#define FORWARD_WM_SETREDRAW(hwnd,fRedraw,fn) (void)(fn)((hwnd),WM_SETREDRAW,(WPARAM)(WINBOOL)(fRedraw),(LPARAM)0)
+
+#define HANDLE_WM_ENABLE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(WINBOOL)(wParam)),(LRESULT)0)
+#define FORWARD_WM_ENABLE(hwnd,fEnable,fn) (void)(fn)((hwnd),WM_ENABLE,(WPARAM)(WINBOOL)(fEnable),(LPARAM)0)
+
+#define HANDLE_WM_SETTEXT(hwnd,wParam,lParam,fn) ((fn)((hwnd),(LPCTSTR)(lParam)),(LRESULT)0)
+#define FORWARD_WM_SETTEXT(hwnd,lpszText,fn) (void)(fn)((hwnd),WM_SETTEXT,(WPARAM)0,(LPARAM)(LPCTSTR)(lpszText))
+
+#define HANDLE_WM_GETTEXT(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(int)(fn)((hwnd),(int)(wParam),(LPTSTR)(lParam))
+#define FORWARD_WM_GETTEXT(hwnd,cchTextMax,lpszText,fn) (int)(DWORD)(fn)((hwnd),WM_GETTEXT,(WPARAM)(int)(cchTextMax),(LPARAM)(LPTSTR)(lpszText))
+
+#define HANDLE_WM_GETTEXTLENGTH(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(int)(fn)(hwnd)
+#define FORWARD_WM_GETTEXTLENGTH(hwnd,fn) (int)(DWORD)(fn)((hwnd),WM_GETTEXTLENGTH,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_WINDOWPOSCHANGING(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(LPWINDOWPOS)(lParam))
+#define FORWARD_WM_WINDOWPOSCHANGING(hwnd,lpwpos,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_WINDOWPOSCHANGING,(WPARAM)0,(LPARAM)(LPWINDOWPOS)(lpwpos))
+
+#define HANDLE_WM_WINDOWPOSCHANGED(hwnd,wParam,lParam,fn) ((fn)((hwnd),(const LPWINDOWPOS)(lParam)),(LRESULT)0)
+#define FORWARD_WM_WINDOWPOSCHANGED(hwnd,lpwpos,fn) (void)(fn)((hwnd),WM_WINDOWPOSCHANGED,(WPARAM)0,(LPARAM)(const LPWINDOWPOS)(lpwpos))
+
+#define HANDLE_WM_MOVE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_MOVE(hwnd,x,y,fn) (void)(fn)((hwnd),WM_MOVE,(WPARAM)0,MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_SIZE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SIZE(hwnd,state,cx,cy,fn) (void)(fn)((hwnd),WM_SIZE,(WPARAM)(UINT)(state),MAKELPARAM((cx),(cy)))
+
+#define HANDLE_WM_CLOSE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_CLOSE(hwnd,fn) (void)(fn)((hwnd),WM_CLOSE,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_QUERYOPEN(hwnd,wParam,lParam,fn) MAKELRESULT((WINBOOL)(fn)(hwnd),0)
+#define FORWARD_WM_QUERYOPEN(hwnd,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_QUERYOPEN,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_GETMINMAXINFO(hwnd,wParam,lParam,fn) ((fn)((hwnd),(LPMINMAXINFO)(lParam)),(LRESULT)0)
+#define FORWARD_WM_GETMINMAXINFO(hwnd,lpMinMaxInfo,fn) (void)(fn)((hwnd),WM_GETMINMAXINFO,(WPARAM)0,(LPARAM)(LPMINMAXINFO)(lpMinMaxInfo))
+
+#define HANDLE_WM_PAINT(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_PAINT(hwnd,fn) (void)(fn)((hwnd),WM_PAINT,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_ERASEBKGND(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(HDC)(wParam))
+#define FORWARD_WM_ERASEBKGND(hwnd,hdc,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_ERASEBKGND,(WPARAM)(HDC)(hdc),(LPARAM)0)
+
+#define HANDLE_WM_ICONERASEBKGND(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(HDC)(wParam))
+#define FORWARD_WM_ICONERASEBKGND(hwnd,hdc,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_ICONERASEBKGND,(WPARAM)(HDC)(hdc),(LPARAM)0)
+
+#define HANDLE_WM_NCPAINT(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HRGN)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCPAINT(hwnd,hrgn,fn) (void)(fn)((hwnd),WM_NCPAINT,(WPARAM)(HRGN)(hrgn),(LPARAM)0)
+
+#define HANDLE_WM_NCCALCSIZE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(UINT)(fn)((hwnd),(WINBOOL)(wParam),(NCCALCSIZE_PARAMS *)(lParam))
+#define FORWARD_WM_NCCALCSIZE(hwnd,fCalcValidRects,lpcsp,fn) (UINT)(DWORD)(fn)((hwnd),WM_NCCALCSIZE,(WPARAM)(fCalcValidRects),(LPARAM)(NCCALCSIZE_PARAMS *)(lpcsp))
+
+#define HANDLE_WM_NCHITTEST(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(UINT)(fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam))
+#define FORWARD_WM_NCHITTEST(hwnd,x,y,fn) (UINT)(DWORD)(fn)((hwnd),WM_NCHITTEST,(WPARAM)0,MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_QUERYDRAGICON(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(UINT)(fn)(hwnd)
+#define FORWARD_WM_QUERYDRAGICON(hwnd,fn) (HICON)(UINT)(DWORD)(fn)((hwnd),WM_QUERYDRAGICON,(WPARAM)0,(LPARAM)0)
+
+#ifdef _INC_SHELLAPI
+
+#define HANDLE_WM_DROPFILES(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HDROP)(wParam)),(LRESULT)0)
+#define FORWARD_WM_DROPFILES(hwnd,hdrop,fn) (void)(fn)((hwnd),WM_DROPFILES,(WPARAM)(HDROP)(hdrop),(LPARAM)0)
+#endif
+
+#define HANDLE_WM_ACTIVATE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)LOWORD(wParam),(HWND)(lParam),(WINBOOL)HIWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_ACTIVATE(hwnd,state,hwndActDeact,fMinimized,fn) (void)(fn)((hwnd),WM_ACTIVATE,MAKEWPARAM((state),(fMinimized)),(LPARAM)(HWND)(hwndActDeact))
+
+#define HANDLE_WM_ACTIVATEAPP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(WINBOOL)(wParam),(DWORD)(lParam)),(LRESULT)0)
+#define FORWARD_WM_ACTIVATEAPP(hwnd,fActivate,dwThreadId,fn) (void)(fn)((hwnd),WM_ACTIVATEAPP,(WPARAM)(WINBOOL)(fActivate),(LPARAM)(dwThreadId))
+
+#define HANDLE_WM_NCACTIVATE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(WINBOOL)(wParam),(WPARAM)0,(LPARAM)0)
+#define FORWARD_WM_NCACTIVATE(hwnd,fActive,hwndActDeact,fMinimized,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_NCACTIVATE,(WPARAM)(WINBOOL)(fActive),(LPARAM)0)
+
+#define HANDLE_WM_SETFOCUS(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_SETFOCUS(hwnd,hwndOldFocus,fn) (void)(fn)((hwnd),WM_SETFOCUS,(WPARAM)(HWND)(hwndOldFocus),(LPARAM)0)
+
+#define HANDLE_WM_KILLFOCUS(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_KILLFOCUS(hwnd,hwndNewFocus,fn) (void)(fn)((hwnd),WM_KILLFOCUS,(WPARAM)(HWND)(hwndNewFocus),(LPARAM)0)
+
+#define HANDLE_WM_KEYDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),TRUE,(int)(short)LOWORD(lParam),(UINT)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_KEYDOWN(hwnd,vk,cRepeat,flags,fn) (void)(fn)((hwnd),WM_KEYDOWN,(WPARAM)(UINT)(vk),MAKELPARAM((cRepeat),(flags)))
+
+#define HANDLE_WM_KEYUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),FALSE,(int)(short)LOWORD(lParam),(UINT)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_KEYUP(hwnd,vk,cRepeat,flags,fn) (void)(fn)((hwnd),WM_KEYUP,(WPARAM)(UINT)(vk),MAKELPARAM((cRepeat),(flags)))
+
+#define HANDLE_WM_CHAR(hwnd,wParam,lParam,fn) ((fn)((hwnd),(TCHAR)(wParam),(int)(short)LOWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_CHAR(hwnd,ch,cRepeat,fn) (void)(fn)((hwnd),WM_CHAR,(WPARAM)(TCHAR)(ch),MAKELPARAM((cRepeat),0))
+
+#define HANDLE_WM_DEADCHAR(hwnd,wParam,lParam,fn) ((fn)((hwnd),(TCHAR)(wParam),(int)(short)LOWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_DEADCHAR(hwnd,ch,cRepeat,fn) (void)(fn)((hwnd),WM_DEADCHAR,(WPARAM)(TCHAR)(ch),MAKELPARAM((cRepeat),0))
+
+#define HANDLE_WM_SYSKEYDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),TRUE,(int)(short)LOWORD(lParam),(UINT)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SYSKEYDOWN(hwnd,vk,cRepeat,flags,fn) (void)(fn)((hwnd),WM_SYSKEYDOWN,(WPARAM)(UINT)(vk),MAKELPARAM((cRepeat),(flags)))
+
+#define HANDLE_WM_SYSKEYUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),FALSE,(int)(short)LOWORD(lParam),(UINT)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SYSKEYUP(hwnd,vk,cRepeat,flags,fn) (void)(fn)((hwnd),WM_SYSKEYUP,(WPARAM)(UINT)(vk),MAKELPARAM((cRepeat),(flags)))
+
+#define HANDLE_WM_SYSCHAR(hwnd,wParam,lParam,fn) ((fn)((hwnd),(TCHAR)(wParam),(int)(short)LOWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SYSCHAR(hwnd,ch,cRepeat,fn) (void)(fn)((hwnd),WM_SYSCHAR,(WPARAM)(TCHAR)(ch),MAKELPARAM((cRepeat),0))
+
+#define HANDLE_WM_SYSDEADCHAR(hwnd,wParam,lParam,fn) ((fn)((hwnd),(TCHAR)(wParam),(int)(short)LOWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SYSDEADCHAR(hwnd,ch,cRepeat,fn) (void)(fn)((hwnd),WM_SYSDEADCHAR,(WPARAM)(TCHAR)(ch),MAKELPARAM((cRepeat),0))
+
+#define HANDLE_WM_MOUSEMOVE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MOUSEMOVE(hwnd,x,y,keyFlags,fn) (void)(fn)((hwnd),WM_MOUSEMOVE,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_LBUTTONDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),FALSE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_LBUTTONDOWN(hwnd,fDoubleClick,x,y,keyFlags,fn) (void)(fn)((hwnd),(fDoubleClick) ? WM_LBUTTONDBLCLK : WM_LBUTTONDOWN,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_LBUTTONDBLCLK(hwnd,wParam,lParam,fn) ((fn)((hwnd),TRUE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+
+#define HANDLE_WM_LBUTTONUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_LBUTTONUP(hwnd,x,y,keyFlags,fn) (void)(fn)((hwnd),WM_LBUTTONUP,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_RBUTTONDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),FALSE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_RBUTTONDOWN(hwnd,fDoubleClick,x,y,keyFlags,fn) (void)(fn)((hwnd),(fDoubleClick) ? WM_RBUTTONDBLCLK : WM_RBUTTONDOWN,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_RBUTTONDBLCLK(hwnd,wParam,lParam,fn) ((fn)((hwnd),TRUE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+
+#define HANDLE_WM_RBUTTONUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_RBUTTONUP(hwnd,x,y,keyFlags,fn) (void)(fn)((hwnd),WM_RBUTTONUP,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_MBUTTONDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),FALSE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MBUTTONDOWN(hwnd,fDoubleClick,x,y,keyFlags,fn) (void)(fn)((hwnd),(fDoubleClick) ? WM_MBUTTONDBLCLK : WM_MBUTTONDOWN,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_MBUTTONDBLCLK(hwnd,wParam,lParam,fn) ((fn)((hwnd),TRUE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+
+#define HANDLE_WM_MBUTTONUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MBUTTONUP(hwnd,x,y,keyFlags,fn) (void)(fn)((hwnd),WM_MBUTTONUP,(WPARAM)(UINT)(keyFlags),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_MOUSEWHEEL(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(int)(short)HIWORD(wParam),(UINT)(short)LOWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_MOUSEWHEEL(hwnd,xPos,yPos,zDelta,fwKeys,fn) (void)(fn)((hwnd),WM_MOUSEWHEEL,MAKEWPARAM((fwKeys),(zDelta)),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCMOUSEMOVE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCMOUSEMOVE(hwnd,x,y,codeHitTest,fn) (void)(fn)((hwnd),WM_NCMOUSEMOVE,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCLBUTTONDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),FALSE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCLBUTTONDOWN(hwnd,fDoubleClick,x,y,codeHitTest,fn) (void)(fn)((hwnd),(fDoubleClick) ? WM_NCLBUTTONDBLCLK : WM_NCLBUTTONDOWN,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCLBUTTONDBLCLK(hwnd,wParam,lParam,fn) ((fn)((hwnd),TRUE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+
+#define HANDLE_WM_NCLBUTTONUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCLBUTTONUP(hwnd,x,y,codeHitTest,fn) (void)(fn)((hwnd),WM_NCLBUTTONUP,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCRBUTTONDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),FALSE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCRBUTTONDOWN(hwnd,fDoubleClick,x,y,codeHitTest,fn) (void)(fn)((hwnd),(fDoubleClick) ? WM_NCRBUTTONDBLCLK : WM_NCRBUTTONDOWN,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCRBUTTONDBLCLK(hwnd,wParam,lParam,fn) ((fn)((hwnd),TRUE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+
+#define HANDLE_WM_NCRBUTTONUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCRBUTTONUP(hwnd,x,y,codeHitTest,fn) (void)(fn)((hwnd),WM_NCRBUTTONUP,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCMBUTTONDOWN(hwnd,wParam,lParam,fn) ((fn)((hwnd),FALSE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCMBUTTONDOWN(hwnd,fDoubleClick,x,y,codeHitTest,fn) (void)(fn)((hwnd),(fDoubleClick) ? WM_NCMBUTTONDBLCLK : WM_NCMBUTTONDOWN,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_NCMBUTTONDBLCLK(hwnd,wParam,lParam,fn) ((fn)((hwnd),TRUE,(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+
+#define HANDLE_WM_NCMBUTTONUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_NCMBUTTONUP(hwnd,x,y,codeHitTest,fn) (void)(fn)((hwnd),WM_NCMBUTTONUP,(WPARAM)(UINT)(codeHitTest),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_MOUSEACTIVATE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(int)(fn)((hwnd),(HWND)(wParam),(UINT)LOWORD(lParam),(UINT)HIWORD(lParam))
+#define FORWARD_WM_MOUSEACTIVATE(hwnd,hwndTopLevel,codeHitTest,msg,fn) (int)(DWORD)(fn)((hwnd),WM_MOUSEACTIVATE,(WPARAM)(HWND)(hwndTopLevel),MAKELPARAM((codeHitTest),(msg)))
+
+#define HANDLE_WM_CANCELMODE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_CANCELMODE(hwnd,fn) (void)(fn)((hwnd),WM_CANCELMODE,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_TIMER(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam)),(LRESULT)0)
+#define FORWARD_WM_TIMER(hwnd,id,fn) (void)(fn)((hwnd),WM_TIMER,(WPARAM)(UINT)(id),(LPARAM)0)
+
+#define HANDLE_WM_INITMENU(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HMENU)(wParam)),(LRESULT)0)
+#define FORWARD_WM_INITMENU(hwnd,hMenu,fn) (void)(fn)((hwnd),WM_INITMENU,(WPARAM)(HMENU)(hMenu),(LPARAM)0)
+
+#define HANDLE_WM_INITMENUPOPUP(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HMENU)(wParam),(UINT)LOWORD(lParam),(WINBOOL)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_INITMENUPOPUP(hwnd,hMenu,item,fSystemMenu,fn) (void)(fn)((hwnd),WM_INITMENUPOPUP,(WPARAM)(HMENU)(hMenu),MAKELPARAM((item),(fSystemMenu)))
+
+#define HANDLE_WM_MENUSELECT(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HMENU)(lParam),(HIWORD(wParam) & MF_POPUP) ? 0 : (int)(LOWORD(wParam)),(HIWORD(wParam) & MF_POPUP) ? GetSubMenu((HMENU)lParam,LOWORD(wParam)) : (HMENU)0,(UINT)(((short)HIWORD(wParam)==-1) ? 0xFFFFFFFF : HIWORD(wParam))),(LRESULT)0)
+#define FORWARD_WM_MENUSELECT(hwnd,hmenu,item,hmenuPopup,flags,fn) (void)(fn)((hwnd),WM_MENUSELECT,MAKEWPARAM((item),(flags)),(LPARAM)(HMENU)((hmenu) ? (hmenu) : (hmenuPopup)))
+
+#define HANDLE_WM_MENUCHAR(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(fn)((hwnd),(UINT)(LOWORD(wParam)),(UINT)HIWORD(wParam),(HMENU)(lParam))
+#define FORWARD_WM_MENUCHAR(hwnd,ch,flags,hmenu,fn) (DWORD)(fn)((hwnd),WM_MENUCHAR,MAKEWPARAM(flags,(WORD)(ch)),(LPARAM)(HMENU)(hmenu))
+
+#define HANDLE_WM_COMMAND(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(LOWORD(wParam)),(HWND)(lParam),(UINT)HIWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_COMMAND(hwnd,id,hwndCtl,codeNotify,fn) (void)(fn)((hwnd),WM_COMMAND,MAKEWPARAM((UINT)(id),(UINT)(codeNotify)),(LPARAM)(HWND)(hwndCtl))
+
+#define HANDLE_WM_HSCROLL(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(lParam),(UINT)(LOWORD(wParam)),(int)(short)HIWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_HSCROLL(hwnd,hwndCtl,code,pos,fn) (void)(fn)((hwnd),WM_HSCROLL,MAKEWPARAM((UINT)(int)(code),(UINT)(int)(pos)),(LPARAM)(HWND)(hwndCtl))
+
+#define HANDLE_WM_VSCROLL(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(lParam),(UINT)(LOWORD(wParam)),(int)(short)HIWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_VSCROLL(hwnd,hwndCtl,code,pos,fn) (void)(fn)((hwnd),WM_VSCROLL,MAKEWPARAM((UINT)(int)(code),(UINT)(int)(pos)),(LPARAM)(HWND)(hwndCtl))
+
+#define HANDLE_WM_CUT(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_CUT(hwnd,fn) (void)(fn)((hwnd),WM_CUT,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_COPY(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_COPY(hwnd,fn) (void)(fn)((hwnd),WM_COPY,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_PASTE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_PASTE(hwnd,fn) (void)(fn)((hwnd),WM_PASTE,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_CLEAR(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_CLEAR(hwnd,fn) (void)(fn)((hwnd),WM_CLEAR,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_UNDO(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_UNDO(hwnd,fn) (void)(fn)((hwnd),WM_UNDO,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_RENDERFORMAT(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HANDLE)(fn)((hwnd),(UINT)(wParam))
+#define FORWARD_WM_RENDERFORMAT(hwnd,fmt,fn) (HANDLE)(UINT_PTR)(fn)((hwnd),WM_RENDERFORMAT,(WPARAM)(UINT)(fmt),(LPARAM)0)
+
+#define HANDLE_WM_RENDERALLFORMATS(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_RENDERALLFORMATS(hwnd,fn) (void)(fn)((hwnd),WM_RENDERALLFORMATS,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_DESTROYCLIPBOARD(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_DESTROYCLIPBOARD(hwnd,fn) (void)(fn)((hwnd),WM_DESTROYCLIPBOARD,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_DRAWCLIPBOARD(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_DRAWCLIPBOARD(hwnd,fn) (void)(fn)((hwnd),WM_DRAWCLIPBOARD,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_PAINTCLIPBOARD(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(const LPPAINTSTRUCT)GlobalLock((HGLOBAL)(lParam))),GlobalUnlock((HGLOBAL)(lParam)),(LRESULT)0)
+#define FORWARD_WM_PAINTCLIPBOARD(hwnd,hwndCBViewer,lpPaintStruct,fn) (void)(fn)((hwnd),WM_PAINTCLIPBOARD,(WPARAM)(HWND)(hwndCBViewer),(LPARAM)(LPPAINTSTRUCT)(lpPaintStruct))
+
+#define HANDLE_WM_SIZECLIPBOARD(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(const LPRECT)GlobalLock((HGLOBAL)(lParam))),GlobalUnlock((HGLOBAL)(lParam)),(LRESULT)0)
+#define FORWARD_WM_SIZECLIPBOARD(hwnd,hwndCBViewer,lprc,fn) (void)(fn)((hwnd),WM_SIZECLIPBOARD,(WPARAM)(HWND)(hwndCBViewer),(LPARAM)(LPRECT)(lprc))
+
+#define HANDLE_WM_VSCROLLCLIPBOARD(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(UINT)LOWORD(lParam),(int)(short)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_VSCROLLCLIPBOARD(hwnd,hwndCBViewer,code,pos,fn) (void)(fn)((hwnd),WM_VSCROLLCLIPBOARD,(WPARAM)(HWND)(hwndCBViewer),MAKELPARAM((code),(pos)))
+
+#define HANDLE_WM_HSCROLLCLIPBOARD(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(UINT)LOWORD(lParam),(int)(short)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_HSCROLLCLIPBOARD(hwnd,hwndCBViewer,code,pos,fn) (void)(fn)((hwnd),WM_HSCROLLCLIPBOARD,(WPARAM)(HWND)(hwndCBViewer),MAKELPARAM((code),(pos)))
+
+#define HANDLE_WM_ASKCBFORMATNAME(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(wParam),(LPTSTR)(lParam)),(LRESULT)0)
+#define FORWARD_WM_ASKCBFORMATNAME(hwnd,cchMax,rgchName,fn) (void)(fn)((hwnd),WM_ASKCBFORMATNAME,(WPARAM)(int)(cchMax),(LPARAM)(rgchName))
+
+#define HANDLE_WM_CHANGECBCHAIN(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(HWND)(lParam)),(LRESULT)0)
+#define FORWARD_WM_CHANGECBCHAIN(hwnd,hwndRemove,hwndNext,fn) (void)(fn)((hwnd),WM_CHANGECBCHAIN,(WPARAM)(HWND)(hwndRemove),(LPARAM)(HWND)(hwndNext))
+
+#define HANDLE_WM_SETCURSOR(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(HWND)(wParam),(UINT)LOWORD(lParam),(UINT)HIWORD(lParam))
+#define FORWARD_WM_SETCURSOR(hwnd,hwndCursor,codeHitTest,msg,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_SETCURSOR,(WPARAM)(HWND)(hwndCursor),MAKELPARAM((codeHitTest),(msg)))
+
+#define HANDLE_WM_SYSCOMMAND(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),(int)(short)LOWORD(lParam),(int)(short)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_SYSCOMMAND(hwnd,cmd,x,y,fn) (void)(fn)((hwnd),WM_SYSCOMMAND,(WPARAM)(UINT)(cmd),MAKELPARAM((x),(y)))
+
+#define HANDLE_WM_MDICREATE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(UINT)(fn)((hwnd),(LPMDICREATESTRUCT)(lParam))
+#define FORWARD_WM_MDICREATE(hwnd,lpmcs,fn) (HWND)(UINT)(DWORD)(fn)((hwnd),WM_MDICREATE,(WPARAM)0,(LPARAM)(LPMDICREATESTRUCT)(lpmcs))
+
+#define HANDLE_WM_MDIDESTROY(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MDIDESTROY(hwnd,hwndDestroy,fn) (void)(fn)((hwnd),WM_MDIDESTROY,(WPARAM)(hwndDestroy),(LPARAM)0)
+
+#define HANDLE_WM_MDIACTIVATE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(WINBOOL)(lParam==(LPARAM)hwnd),(HWND)(lParam),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MDIACTIVATE(hwnd,fActive,hwndActivate,hwndDeactivate,fn) (void)(fn)(hwnd,WM_MDIACTIVATE,(WPARAM)(hwndDeactivate),(LPARAM)(hwndActivate))
+
+#define HANDLE_WM_MDIRESTORE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MDIRESTORE(hwnd,hwndRestore,fn) (void)(fn)((hwnd),WM_MDIRESTORE,(WPARAM)(hwndRestore),(LPARAM)0)
+
+#define HANDLE_WM_MDINEXT(hwnd,wParam,lParam,fn) (LRESULT)(HWND)(fn)((hwnd),(HWND)(wParam),(WINBOOL)lParam)
+#define FORWARD_WM_MDINEXT(hwnd,hwndCur,fPrev,fn) (HWND)(UINT_PTR)(fn)((hwnd),WM_MDINEXT,(WPARAM)(hwndCur),(LPARAM)(fPrev))
+
+#define HANDLE_WM_MDIMAXIMIZE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam)),(LRESULT)0)
+#define FORWARD_WM_MDIMAXIMIZE(hwnd,hwndMaximize,fn) (void)(fn)((hwnd),WM_MDIMAXIMIZE,(WPARAM)(hwndMaximize),(LPARAM)0)
+
+#define HANDLE_WM_MDITILE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(fn)((hwnd),(UINT)(wParam))
+#define FORWARD_WM_MDITILE(hwnd,cmd,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_MDITILE,(WPARAM)(cmd),(LPARAM)0)
+
+#define HANDLE_WM_MDICASCADE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(fn)((hwnd),(UINT)(wParam))
+#define FORWARD_WM_MDICASCADE(hwnd,cmd,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_MDICASCADE,(WPARAM)(cmd),(LPARAM)0)
+
+#define HANDLE_WM_MDIICONARRANGE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_MDIICONARRANGE(hwnd,fn) (void)(fn)((hwnd),WM_MDIICONARRANGE,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_MDIGETACTIVE(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(fn)(hwnd)
+#define FORWARD_WM_MDIGETACTIVE(hwnd,fn) (HWND)(UINT_PTR)(fn)((hwnd),WM_MDIGETACTIVE,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_MDISETMENU(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(fn)((hwnd),(WINBOOL)(wParam),(HMENU)(wParam),(HMENU)(lParam))
+#define FORWARD_WM_MDISETMENU(hwnd,fRefresh,hmenuFrame,hmenuWindow,fn) (HMENU)(UINT_PTR)(fn)((hwnd),WM_MDISETMENU,(WPARAM)((fRefresh) ? (hmenuFrame) : 0),(LPARAM)(hmenuWindow))
+
+#define HANDLE_WM_CHILDACTIVATE(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_CHILDACTIVATE(hwnd,fn) (void)(fn)((hwnd),WM_CHILDACTIVATE,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_INITDIALOG(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(UINT)(WINBOOL)(fn)((hwnd),(HWND)(wParam),lParam)
+#define FORWARD_WM_INITDIALOG(hwnd,hwndFocus,lParam,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_INITDIALOG,(WPARAM)(HWND)(hwndFocus),(lParam))
+
+#define HANDLE_WM_NEXTDLGCTL(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HWND)(fn)((hwnd),(HWND)(wParam),(WINBOOL)(lParam))
+#define FORWARD_WM_NEXTDLGCTL(hwnd,hwndSetFocus,fNext,fn) (HWND)(UINT_PTR)(fn)((hwnd),WM_NEXTDLGCTL,(WPARAM)(HWND)(hwndSetFocus),(LPARAM)(fNext))
+
+#define HANDLE_WM_PARENTNOTIFY(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)LOWORD(wParam),(HWND)(lParam),(UINT)HIWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_PARENTNOTIFY(hwnd,msg,hwndChild,idChild,fn) (void)(fn)((hwnd),WM_PARENTNOTIFY,MAKEWPARAM(msg,idChild),(LPARAM)(hwndChild))
+
+#define HANDLE_WM_ENTERIDLE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),(HWND)(lParam)),(LRESULT)0)
+#define FORWARD_WM_ENTERIDLE(hwnd,source,hwndSource,fn) (void)(fn)((hwnd),WM_ENTERIDLE,(WPARAM)(UINT)(source),(LPARAM)(HWND)(hwndSource))
+
+#define HANDLE_WM_GETDLGCODE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(UINT)(fn)(hwnd,(LPMSG)(lParam))
+#define FORWARD_WM_GETDLGCODE(hwnd,lpmsg,fn) (UINT)(DWORD)(fn)((hwnd),WM_GETDLGCODE,(lpmsg ? lpmsg->wParam : 0),(LPARAM)(LPMSG)(lpmsg))
+
+#define HANDLE_WM_CTLCOLORMSGBOX(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_MSGBOX)
+#define FORWARD_WM_CTLCOLORMSGBOX(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLORMSGBOX,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_CTLCOLOREDIT(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_EDIT)
+#define FORWARD_WM_CTLCOLOREDIT(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLOREDIT,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_CTLCOLORLISTBOX(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_LISTBOX)
+#define FORWARD_WM_CTLCOLORLISTBOX(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLORLISTBOX,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_CTLCOLORBTN(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_BTN)
+#define FORWARD_WM_CTLCOLORBTN(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLORBTN,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_CTLCOLORDLG(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_DLG)
+#define FORWARD_WM_CTLCOLORDLG(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLORDLG,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_CTLCOLORSCROLLBAR(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_SCROLLBAR)
+#define FORWARD_WM_CTLCOLORSCROLLBAR(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLORSCROLLBAR,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_CTLCOLORSTATIC(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HBRUSH)(fn)((hwnd),(HDC)(wParam),(HWND)(lParam),CTLCOLOR_STATIC)
+#define FORWARD_WM_CTLCOLORSTATIC(hwnd,hdc,hwndChild,fn) (HBRUSH)(UINT_PTR)(fn)((hwnd),WM_CTLCOLORSTATIC,(WPARAM)(HDC)(hdc),(LPARAM)(HWND)(hwndChild))
+
+#define HANDLE_WM_SETFONT(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HFONT)(wParam),(WINBOOL)(lParam)),(LRESULT)0)
+#define FORWARD_WM_SETFONT(hwnd,hfont,fRedraw,fn) (void)(fn)((hwnd),WM_SETFONT,(WPARAM)(HFONT)(hfont),(LPARAM)(WINBOOL)(fRedraw))
+
+#define HANDLE_WM_GETFONT(hwnd,wParam,lParam,fn) (LRESULT)(UINT_PTR)(HFONT)(fn)(hwnd)
+#define FORWARD_WM_GETFONT(hwnd,fn) (HFONT)(UINT_PTR)(fn)((hwnd),WM_GETFONT,(WPARAM)0,(LPARAM)0)
+
+#define HANDLE_WM_DRAWITEM(hwnd,wParam,lParam,fn) ((fn)((hwnd),(const DRAWITEMSTRUCT *)(lParam)),(LRESULT)0)
+#define FORWARD_WM_DRAWITEM(hwnd,lpDrawItem,fn) (void)(fn)((hwnd),WM_DRAWITEM,(WPARAM)(((const DRAWITEMSTRUCT *)lpDrawItem)->CtlID),(LPARAM)(const DRAWITEMSTRUCT *)(lpDrawItem))
+
+#define HANDLE_WM_MEASUREITEM(hwnd,wParam,lParam,fn) ((fn)((hwnd),(MEASUREITEMSTRUCT *)(lParam)),(LRESULT)0)
+#define FORWARD_WM_MEASUREITEM(hwnd,lpMeasureItem,fn) (void)(fn)((hwnd),WM_MEASUREITEM,(WPARAM)(((MEASUREITEMSTRUCT *)lpMeasureItem)->CtlID),(LPARAM)(MEASUREITEMSTRUCT *)(lpMeasureItem))
+
+#define HANDLE_WM_DELETEITEM(hwnd,wParam,lParam,fn) ((fn)((hwnd),(const DELETEITEMSTRUCT *)(lParam)),(LRESULT)0)
+#define FORWARD_WM_DELETEITEM(hwnd,lpDeleteItem,fn) (void)(fn)((hwnd),WM_DELETEITEM,(WPARAM)(((const DELETEITEMSTRUCT *)(lpDeleteItem))->CtlID),(LPARAM)(const DELETEITEMSTRUCT *)(lpDeleteItem))
+
+#define HANDLE_WM_COMPAREITEM(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(int)(fn)((hwnd),(const COMPAREITEMSTRUCT *)(lParam))
+#define FORWARD_WM_COMPAREITEM(hwnd,lpCompareItem,fn) (int)(DWORD)(fn)((hwnd),WM_COMPAREITEM,(WPARAM)(((const COMPAREITEMSTRUCT *)(lpCompareItem))->CtlID),(LPARAM)(const COMPAREITEMSTRUCT *)(lpCompareItem))
+
+#define HANDLE_WM_VKEYTOITEM(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(int)(fn)((hwnd),(UINT)LOWORD(wParam),(HWND)(lParam),(int)(short)HIWORD(wParam))
+#define FORWARD_WM_VKEYTOITEM(hwnd,vk,hwndListBox,iCaret,fn) (int)(DWORD)(fn)((hwnd),WM_VKEYTOITEM,MAKEWPARAM((vk),(iCaret)),(LPARAM)(hwndListBox))
+
+#define HANDLE_WM_CHARTOITEM(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(int)(fn)((hwnd),(UINT)LOWORD(wParam),(HWND)(lParam),(int)(short)HIWORD(wParam))
+#define FORWARD_WM_CHARTOITEM(hwnd,ch,hwndListBox,iCaret,fn) (int)(DWORD)(fn)((hwnd),WM_CHARTOITEM,MAKEWPARAM((UINT)(ch),(UINT)(iCaret)),(LPARAM)(hwndListBox))
+
+#define HANDLE_WM_QUEUESYNC(hwnd,wParam,lParam,fn) ((fn)(hwnd),(LRESULT)0)
+#define FORWARD_WM_QUEUESYNC(hwnd,fn) (void)(fn)((hwnd),WM_QUEUESYNC,(WPARAM)0,(LPARAM)0)
+#define HANDLE_WM_COMMNOTIFY(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(wParam),(UINT)LOWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_COMMNOTIFY(hwnd,cid,flags,fn) (void)(fn)((hwnd),WM_COMMNOTIFY,(WPARAM)(cid),MAKELPARAM((flags),0))
+
+#define HANDLE_WM_DISPLAYCHANGE(hwnd,wParam,lParam,fn) ((fn)((hwnd),(UINT)(wParam),(UINT)LOWORD(lParam),(UINT)HIWORD(wParam)),(LRESULT)0)
+#define FORWARD_WM_DISPLAYCHANGE(hwnd,bitsPerPixel,cxScreen,cyScreen,fn) (void)(fn)((hwnd),WM_DISPLAYCHANGE,(WPARAM)(UINT)(bitsPerPixel),(LPARAM)MAKELPARAM((UINT)(cxScreen),(UINT)(cyScreen)))
+
+#define HANDLE_WM_DEVICECHANGE(hwnd,wParam,lParam,fn) (LRESULT)(DWORD)(WINBOOL)(fn)((hwnd),(UINT)(wParam),(DWORD)(wParam))
+#define FORWARD_WM_DEVICECHANGE(hwnd,uEvent,dwEventData,fn) (WINBOOL)(DWORD)(fn)((hwnd),WM_DEVICECHANGE,(WPARAM)(UINT)(uEvent),(LPARAM)(DWORD)(dwEventData))
+
+#define HANDLE_WM_CONTEXTMENU(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(UINT)LOWORD(lParam),(UINT)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_CONTEXTMENU(hwnd,hwndContext,xPos,yPos,fn) (void)(fn)((hwnd),WM_CONTEXTMENU,(WPARAM)(HWND)(hwndContext),MAKELPARAM((UINT)(xPos),(UINT)(yPos)))
+
+#define HANDLE_WM_COPYDATA(hwnd,wParam,lParam,fn) ((fn)((hwnd),(HWND)(wParam),(PCOPYDATASTRUCT)lParam),(LRESULT)0)
+#define FORWARD_WM_COPYDATA(hwnd,hwndFrom,pcds,fn) (WINBOOL)(UINT)(DWORD)(fn)((hwnd),WM_COPYDATA,(WPARAM)(hwndFrom),(LPARAM)(pcds))
+
+#define HANDLE_WM_HOTKEY(hwnd,wParam,lParam,fn) ((fn)((hwnd),(int)(wParam),(UINT)LOWORD(lParam),(UINT)HIWORD(lParam)),(LRESULT)0)
+#define FORWARD_WM_HOTKEY(hwnd,idHotKey,fuModifiers,vk,fn) (void)(fn)((hwnd),WM_HOTKEY,(WPARAM)(idHotKey),MAKELPARAM((fuModifiers),(vk)))
+
+#define Static_Enable(hwndCtl,fEnable) EnableWindow((hwndCtl),(fEnable))
+
+#define Static_GetText(hwndCtl,lpch,cchMax) GetWindowText((hwndCtl),(lpch),(cchMax))
+#define Static_GetTextLength(hwndCtl) GetWindowTextLength(hwndCtl)
+#define Static_SetText(hwndCtl,lpsz) SetWindowText((hwndCtl),(lpsz))
+
+#define Static_SetIcon(hwndCtl,hIcon) ((HICON)(UINT_PTR)SNDMSG((hwndCtl),STM_SETICON,(WPARAM)(HICON)(hIcon),(LPARAM)0))
+#define Static_GetIcon(hwndCtl,hIcon) ((HICON)(UINT_PTR)SNDMSG((hwndCtl),STM_GETICON,(WPARAM)0,(LPARAM)0))
+
+#define Button_Enable(hwndCtl,fEnable) EnableWindow((hwndCtl),(fEnable))
+
+#define Button_GetText(hwndCtl,lpch,cchMax) GetWindowText((hwndCtl),(lpch),(cchMax))
+#define Button_GetTextLength(hwndCtl) GetWindowTextLength(hwndCtl)
+#define Button_SetText(hwndCtl,lpsz) SetWindowText((hwndCtl),(lpsz))
+
+#define Button_GetCheck(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),BM_GETCHECK,(WPARAM)0,(LPARAM)0))
+#define Button_SetCheck(hwndCtl,check) ((void)SNDMSG((hwndCtl),BM_SETCHECK,(WPARAM)(int)(check),(LPARAM)0))
+
+#define Button_GetState(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),BM_GETSTATE,(WPARAM)0,(LPARAM)0))
+#define Button_SetState(hwndCtl,state) ((UINT)(DWORD)SNDMSG((hwndCtl),BM_SETSTATE,(WPARAM)(int)(state),(LPARAM)0))
+#define Button_SetStyle(hwndCtl,style,fRedraw) ((void)SNDMSG((hwndCtl),BM_SETSTYLE,(WPARAM)LOWORD(style),MAKELPARAM(((fRedraw) ? TRUE : FALSE),0)))
+
+#define Edit_Enable(hwndCtl,fEnable) EnableWindow((hwndCtl),(fEnable))
+#define Edit_GetText(hwndCtl,lpch,cchMax) GetWindowText((hwndCtl),(lpch),(cchMax))
+#define Edit_GetTextLength(hwndCtl) GetWindowTextLength(hwndCtl)
+#define Edit_SetText(hwndCtl,lpsz) SetWindowText((hwndCtl),(lpsz))
+#define Edit_LimitText(hwndCtl,cchMax) ((void)SNDMSG((hwndCtl),EM_LIMITTEXT,(WPARAM)(cchMax),(LPARAM)0))
+#define Edit_GetLineCount(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),EM_GETLINECOUNT,(WPARAM)0,(LPARAM)0))
+#define Edit_GetLine(hwndCtl,line,lpch,cchMax) ((*((int *)(lpch)) = (cchMax)),((int)(DWORD)SNDMSG((hwndCtl),EM_GETLINE,(WPARAM)(int)(line),(LPARAM)(LPTSTR)(lpch))))
+#define Edit_GetRect(hwndCtl,lprc) ((void)SNDMSG((hwndCtl),EM_GETRECT,(LPARAM)0,(LPARAM)(RECT *)(lprc)))
+#define Edit_SetRect(hwndCtl,lprc) ((void)SNDMSG((hwndCtl),EM_SETRECT,(LPARAM)0,(LPARAM)(const RECT *)(lprc)))
+#define Edit_SetRectNoPaint(hwndCtl,lprc) ((void)SNDMSG((hwndCtl),EM_SETRECTNP,(LPARAM)0,(LPARAM)(const RECT *)(lprc)))
+
+#define Edit_GetSel(hwndCtl) ((DWORD)SNDMSG((hwndCtl),EM_GETSEL,(WPARAM)0,(LPARAM)0))
+#define Edit_SetSel(hwndCtl,ichStart,ichEnd) ((void)SNDMSG((hwndCtl),EM_SETSEL,(ichStart),(ichEnd)))
+#define Edit_ReplaceSel(hwndCtl,lpszReplace) ((void)SNDMSG((hwndCtl),EM_REPLACESEL,(LPARAM)0,(LPARAM)(LPCTSTR)(lpszReplace)))
+
+#define Edit_GetModify(hwndCtl) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),EM_GETMODIFY,(WPARAM)0,(LPARAM)0))
+#define Edit_SetModify(hwndCtl,fModified) ((void)SNDMSG((hwndCtl),EM_SETMODIFY,(WPARAM)(UINT)(fModified),(LPARAM)0))
+
+#define Edit_ScrollCaret(hwndCtl) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),EM_SCROLLCARET,(WPARAM)0,(LPARAM)0))
+
+#define Edit_LineFromChar(hwndCtl,ich) ((int)(DWORD)SNDMSG((hwndCtl),EM_LINEFROMCHAR,(WPARAM)(int)(ich),(LPARAM)0))
+#define Edit_LineIndex(hwndCtl,line) ((int)(DWORD)SNDMSG((hwndCtl),EM_LINEINDEX,(WPARAM)(int)(line),(LPARAM)0))
+#define Edit_LineLength(hwndCtl,line) ((int)(DWORD)SNDMSG((hwndCtl),EM_LINELENGTH,(WPARAM)(int)(line),(LPARAM)0))
+
+#define Edit_Scroll(hwndCtl,dv,dh) ((void)SNDMSG((hwndCtl),EM_LINESCROLL,(WPARAM)(dh),(LPARAM)(dv)))
+
+#define Edit_CanUndo(hwndCtl) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),EM_CANUNDO,(WPARAM)0,(LPARAM)0))
+#define Edit_Undo(hwndCtl) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),EM_UNDO,(WPARAM)0,(LPARAM)0))
+#define Edit_EmptyUndoBuffer(hwndCtl) ((void)SNDMSG((hwndCtl),EM_EMPTYUNDOBUFFER,(WPARAM)0,(LPARAM)0))
+
+#define Edit_SetPasswordChar(hwndCtl,ch) ((void)SNDMSG((hwndCtl),EM_SETPASSWORDCHAR,(WPARAM)(UINT)(ch),(LPARAM)0))
+
+#define Edit_SetTabStops(hwndCtl,cTabs,lpTabs) ((void)SNDMSG((hwndCtl),EM_SETTABSTOPS,(WPARAM)(int)(cTabs),(LPARAM)(const int *)(lpTabs)))
+
+#define Edit_FmtLines(hwndCtl,fAddEOL) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),EM_FMTLINES,(WPARAM)(WINBOOL)(fAddEOL),(LPARAM)0))
+
+#define Edit_GetHandle(hwndCtl) ((HLOCAL)(UINT_PTR)SNDMSG((hwndCtl),EM_GETHANDLE,(WPARAM)0,(LPARAM)0))
+#define Edit_SetHandle(hwndCtl,h) ((void)SNDMSG((hwndCtl),EM_SETHANDLE,(WPARAM)(UINT_PTR)(HLOCAL)(h),(LPARAM)0))
+
+#define Edit_GetFirstVisibleLine(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),EM_GETFIRSTVISIBLELINE,(WPARAM)0,(LPARAM)0))
+
+#define Edit_SetReadOnly(hwndCtl,fReadOnly) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),EM_SETREADONLY,(WPARAM)(WINBOOL)(fReadOnly),(LPARAM)0))
+
+#define Edit_GetPasswordChar(hwndCtl) ((TCHAR)(DWORD)SNDMSG((hwndCtl),EM_GETPASSWORDCHAR,(WPARAM)0,(LPARAM)0))
+
+#define Edit_SetWordBreakProc(hwndCtl,lpfnWordBreak) ((void)SNDMSG((hwndCtl),EM_SETWORDBREAKPROC,(LPARAM)0,(LPARAM)(EDITWORDBREAKPROC)(lpfnWordBreak)))
+#define Edit_GetWordBreakProc(hwndCtl) ((EDITWORDBREAKPROC)SNDMSG((hwndCtl),EM_GETWORDBREAKPROC,(WPARAM)0,(LPARAM)0))
+
+#define ScrollBar_Enable(hwndCtl,flags) EnableScrollBar((hwndCtl),SB_CTL,(flags))
+
+#define ScrollBar_Show(hwndCtl,fShow) ShowWindow((hwndCtl),(fShow) ? SW_SHOWNORMAL : SW_HIDE)
+
+#define ScrollBar_SetPos(hwndCtl,pos,fRedraw) SetScrollPos((hwndCtl),SB_CTL,(pos),(fRedraw))
+#define ScrollBar_GetPos(hwndCtl) GetScrollPos((hwndCtl),SB_CTL)
+
+#define ScrollBar_SetRange(hwndCtl,posMin,posMax,fRedraw) SetScrollRange((hwndCtl),SB_CTL,(posMin),(posMax),(fRedraw))
+#define ScrollBar_GetRange(hwndCtl,lpposMin,lpposMax) GetScrollRange((hwndCtl),SB_CTL,(lpposMin),(lpposMax))
+
+#define ListBox_Enable(hwndCtl,fEnable) EnableWindow((hwndCtl),(fEnable))
+
+#define ListBox_GetCount(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETCOUNT,(WPARAM)0,(LPARAM)0))
+#define ListBox_ResetContent(hwndCtl) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),LB_RESETCONTENT,(WPARAM)0,(LPARAM)0))
+
+#define ListBox_AddString(hwndCtl,lpsz) ((int)(DWORD)SNDMSG((hwndCtl),LB_ADDSTRING,(LPARAM)0,(LPARAM)(LPCTSTR)(lpsz)))
+#define ListBox_InsertString(hwndCtl,index,lpsz) ((int)(DWORD)SNDMSG((hwndCtl),LB_INSERTSTRING,(WPARAM)(int)(index),(LPARAM)(LPCTSTR)(lpsz)))
+
+#define ListBox_AddItemData(hwndCtl,data) ((int)(DWORD)SNDMSG((hwndCtl),LB_ADDSTRING,(LPARAM)0,(LPARAM)(data)))
+#define ListBox_InsertItemData(hwndCtl,index,data) ((int)(DWORD)SNDMSG((hwndCtl),LB_INSERTSTRING,(WPARAM)(int)(index),(LPARAM)(data)))
+
+#define ListBox_DeleteString(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_DELETESTRING,(WPARAM)(int)(index),(LPARAM)0))
+
+#define ListBox_GetTextLen(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETTEXTLEN,(WPARAM)(int)(index),(LPARAM)0))
+#define ListBox_GetText(hwndCtl,index,lpszBuffer) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETTEXT,(WPARAM)(int)(index),(LPARAM)(LPCTSTR)(lpszBuffer)))
+
+#define ListBox_GetItemData(hwndCtl,index) ((LRESULT)(ULONG_PTR)SNDMSG((hwndCtl),LB_GETITEMDATA,(WPARAM)(int)(index),(LPARAM)0))
+#define ListBox_SetItemData(hwndCtl,index,data) ((int)(DWORD)SNDMSG((hwndCtl),LB_SETITEMDATA,(WPARAM)(int)(index),(LPARAM)(data)))
+
+#define ListBox_FindString(hwndCtl,indexStart,lpszFind) ((int)(DWORD)SNDMSG((hwndCtl),LB_FINDSTRING,(WPARAM)(int)(indexStart),(LPARAM)(LPCTSTR)(lpszFind)))
+#define ListBox_FindItemData(hwndCtl,indexStart,data) ((int)(DWORD)SNDMSG((hwndCtl),LB_FINDSTRING,(WPARAM)(int)(indexStart),(LPARAM)(data)))
+
+#define ListBox_SetSel(hwndCtl,fSelect,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_SETSEL,(WPARAM)(WINBOOL)(fSelect),(LPARAM)(index)))
+#define ListBox_SelItemRange(hwndCtl,fSelect,first,last) ((int)(DWORD)SNDMSG((hwndCtl),LB_SELITEMRANGE,(WPARAM)(WINBOOL)(fSelect),MAKELPARAM((first),(last))))
+
+#define ListBox_GetCurSel(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETCURSEL,(WPARAM)0,(LPARAM)0))
+#define ListBox_SetCurSel(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_SETCURSEL,(WPARAM)(int)(index),(LPARAM)0))
+
+#define ListBox_SelectString(hwndCtl,indexStart,lpszFind) ((int)(DWORD)SNDMSG((hwndCtl),LB_SELECTSTRING,(WPARAM)(int)(indexStart),(LPARAM)(LPCTSTR)(lpszFind)))
+#define ListBox_SelectItemData(hwndCtl,indexStart,data) ((int)(DWORD)SNDMSG((hwndCtl),LB_SELECTSTRING,(WPARAM)(int)(indexStart),(LPARAM)(data)))
+
+#define ListBox_GetSel(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETSEL,(WPARAM)(int)(index),(LPARAM)0))
+#define ListBox_GetSelCount(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETSELCOUNT,(WPARAM)0,(LPARAM)0))
+#define ListBox_GetTopIndex(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETTOPINDEX,(WPARAM)0,(LPARAM)0))
+#define ListBox_GetSelItems(hwndCtl,cItems,lpItems) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETSELITEMS,(WPARAM)(int)(cItems),(LPARAM)(int *)(lpItems)))
+
+#define ListBox_SetTopIndex(hwndCtl,indexTop) ((int)(DWORD)SNDMSG((hwndCtl),LB_SETTOPINDEX,(WPARAM)(int)(indexTop),(LPARAM)0))
+
+#define ListBox_SetColumnWidth(hwndCtl,cxColumn) ((void)SNDMSG((hwndCtl),LB_SETCOLUMNWIDTH,(WPARAM)(int)(cxColumn),(LPARAM)0))
+#define ListBox_GetHorizontalExtent(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETHORIZONTALEXTENT,(WPARAM)0,(LPARAM)0))
+#define ListBox_SetHorizontalExtent(hwndCtl,cxExtent) ((void)SNDMSG((hwndCtl),LB_SETHORIZONTALEXTENT,(WPARAM)(int)(cxExtent),(LPARAM)0))
+
+#define ListBox_SetTabStops(hwndCtl,cTabs,lpTabs) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),LB_SETTABSTOPS,(WPARAM)(int)(cTabs),(LPARAM)(int *)(lpTabs)))
+
+#define ListBox_GetItemRect(hwndCtl,index,lprc) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETITEMRECT,(WPARAM)(int)(index),(LPARAM)(RECT *)(lprc)))
+
+#define ListBox_SetCaretIndex(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_SETCARETINDEX,(WPARAM)(int)(index),(LPARAM)0))
+#define ListBox_GetCaretIndex(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETCARETINDEX,(WPARAM)0,(LPARAM)0))
+
+#define ListBox_FindStringExact(hwndCtl,indexStart,lpszFind) ((int)(DWORD)SNDMSG((hwndCtl),LB_FINDSTRINGEXACT,(WPARAM)(int)(indexStart),(LPARAM)(LPCTSTR)(lpszFind)))
+
+#define ListBox_SetItemHeight(hwndCtl,index,cy) ((int)(DWORD)SNDMSG((hwndCtl),LB_SETITEMHEIGHT,(WPARAM)(int)(index),MAKELPARAM((cy),0)))
+#define ListBox_GetItemHeight(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),LB_GETITEMHEIGHT,(WPARAM)(int)(index),(LPARAM)0))
+
+#define ListBox_Dir(hwndCtl,attrs,lpszFileSpec) ((int)(DWORD)SNDMSG((hwndCtl),LB_DIR,(WPARAM)(UINT)(attrs),(LPARAM)(LPCTSTR)(lpszFileSpec)))
+
+#define ComboBox_Enable(hwndCtl,fEnable) EnableWindow((hwndCtl),(fEnable))
+
+#define ComboBox_GetText(hwndCtl,lpch,cchMax) GetWindowText((hwndCtl),(lpch),(cchMax))
+#define ComboBox_GetTextLength(hwndCtl) GetWindowTextLength(hwndCtl)
+#define ComboBox_SetText(hwndCtl,lpsz) SetWindowText((hwndCtl),(lpsz))
+
+#define ComboBox_LimitText(hwndCtl,cchLimit) ((int)(DWORD)SNDMSG((hwndCtl),CB_LIMITTEXT,(WPARAM)(int)(cchLimit),(LPARAM)0))
+
+#define ComboBox_GetEditSel(hwndCtl) ((DWORD)SNDMSG((hwndCtl),CB_GETEDITSEL,(WPARAM)0,(LPARAM)0))
+#define ComboBox_SetEditSel(hwndCtl,ichStart,ichEnd) ((int)(DWORD)SNDMSG((hwndCtl),CB_SETEDITSEL,(LPARAM)0,MAKELPARAM((ichStart),(ichEnd))))
+
+#define ComboBox_GetCount(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),CB_GETCOUNT,(WPARAM)0,(LPARAM)0))
+#define ComboBox_ResetContent(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),CB_RESETCONTENT,(WPARAM)0,(LPARAM)0))
+
+#define ComboBox_AddString(hwndCtl,lpsz) ((int)(DWORD)SNDMSG((hwndCtl),CB_ADDSTRING,(LPARAM)0,(LPARAM)(LPCTSTR)(lpsz)))
+#define ComboBox_InsertString(hwndCtl,index,lpsz) ((int)(DWORD)SNDMSG((hwndCtl),CB_INSERTSTRING,(WPARAM)(int)(index),(LPARAM)(LPCTSTR)(lpsz)))
+
+#define ComboBox_AddItemData(hwndCtl,data) ((int)(DWORD)SNDMSG((hwndCtl),CB_ADDSTRING,(LPARAM)0,(LPARAM)(data)))
+#define ComboBox_InsertItemData(hwndCtl,index,data) ((int)(DWORD)SNDMSG((hwndCtl),CB_INSERTSTRING,(WPARAM)(int)(index),(LPARAM)(data)))
+
+#define ComboBox_DeleteString(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),CB_DELETESTRING,(WPARAM)(int)(index),(LPARAM)0))
+
+#define ComboBox_GetLBTextLen(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),CB_GETLBTEXTLEN,(WPARAM)(int)(index),(LPARAM)0))
+#define ComboBox_GetLBText(hwndCtl,index,lpszBuffer) ((int)(DWORD)SNDMSG((hwndCtl),CB_GETLBTEXT,(WPARAM)(int)(index),(LPARAM)(LPCTSTR)(lpszBuffer)))
+
+#define ComboBox_GetItemData(hwndCtl,index) ((LRESULT)(ULONG_PTR)SNDMSG((hwndCtl),CB_GETITEMDATA,(WPARAM)(int)(index),(LPARAM)0))
+#define ComboBox_SetItemData(hwndCtl,index,data) ((int)(DWORD)SNDMSG((hwndCtl),CB_SETITEMDATA,(WPARAM)(int)(index),(LPARAM)(data)))
+
+#define ComboBox_FindString(hwndCtl,indexStart,lpszFind) ((int)(DWORD)SNDMSG((hwndCtl),CB_FINDSTRING,(WPARAM)(int)(indexStart),(LPARAM)(LPCTSTR)(lpszFind)))
+#define ComboBox_FindItemData(hwndCtl,indexStart,data) ((int)(DWORD)SNDMSG((hwndCtl),CB_FINDSTRING,(WPARAM)(int)(indexStart),(LPARAM)(data)))
+
+#define ComboBox_GetCurSel(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),CB_GETCURSEL,(WPARAM)0,(LPARAM)0))
+#define ComboBox_SetCurSel(hwndCtl,index) ((int)(DWORD)SNDMSG((hwndCtl),CB_SETCURSEL,(WPARAM)(int)(index),(LPARAM)0))
+
+#define ComboBox_SelectString(hwndCtl,indexStart,lpszSelect) ((int)(DWORD)SNDMSG((hwndCtl),CB_SELECTSTRING,(WPARAM)(int)(indexStart),(LPARAM)(LPCTSTR)(lpszSelect)))
+#define ComboBox_SelectItemData(hwndCtl,indexStart,data) ((int)(DWORD)SNDMSG((hwndCtl),CB_SELECTSTRING,(WPARAM)(int)(indexStart),(LPARAM)(data)))
+
+#define ComboBox_Dir(hwndCtl,attrs,lpszFileSpec) ((int)(DWORD)SNDMSG((hwndCtl),CB_DIR,(WPARAM)(UINT)(attrs),(LPARAM)(LPCTSTR)(lpszFileSpec)))
+
+#define ComboBox_ShowDropdown(hwndCtl,fShow) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),CB_SHOWDROPDOWN,(WPARAM)(WINBOOL)(fShow),(LPARAM)0))
+
+#define ComboBox_FindStringExact(hwndCtl,indexStart,lpszFind) ((int)(DWORD)SNDMSG((hwndCtl),CB_FINDSTRINGEXACT,(WPARAM)(int)(indexStart),(LPARAM)(LPCTSTR)(lpszFind)))
+
+#define ComboBox_GetDroppedState(hwndCtl) ((WINBOOL)(DWORD)SNDMSG((hwndCtl),CB_GETDROPPEDSTATE,(WPARAM)0,(LPARAM)0))
+#define ComboBox_GetDroppedControlRect(hwndCtl,lprc) ((void)SNDMSG((hwndCtl),CB_GETDROPPEDCONTROLRECT,(LPARAM)0,(LPARAM)(RECT *)(lprc)))
+
+#define ComboBox_GetItemHeight(hwndCtl) ((int)(DWORD)SNDMSG((hwndCtl),CB_GETITEMHEIGHT,(WPARAM)0,(LPARAM)0))
+#define ComboBox_SetItemHeight(hwndCtl,index,cyItem) ((int)(DWORD)SNDMSG((hwndCtl),CB_SETITEMHEIGHT,(WPARAM)(int)(index),(LPARAM)(int)cyItem))
+
+#define ComboBox_GetExtendedUI(hwndCtl) ((UINT)(DWORD)SNDMSG((hwndCtl),CB_GETEXTENDEDUI,(WPARAM)0,(LPARAM)0))
+#define ComboBox_SetExtendedUI(hwndCtl,flags) ((int)(DWORD)SNDMSG((hwndCtl),CB_SETEXTENDEDUI,(WPARAM)(UINT)(flags),(LPARAM)0))
+
+#define GET_WPARAM(wp,lp) (wp)
+#define GET_LPARAM(wp,lp) (lp)
+
+#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
+#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
+
+#define GET_WM_ACTIVATE_STATE(wp,lp) LOWORD(wp)
+#define GET_WM_ACTIVATE_FMINIMIZED(wp,lp) (WINBOOL)HIWORD(wp)
+#define GET_WM_ACTIVATE_HWND(wp,lp) (HWND)(lp)
+#define GET_WM_ACTIVATE_MPS(s,fmin,hwnd) (WPARAM)MAKELONG((s),(fmin)),(LPARAM)(hwnd)
+
+#define GET_WM_CHARTOITEM_CHAR(wp,lp) (TCHAR)LOWORD(wp)
+#define GET_WM_CHARTOITEM_POS(wp,lp) HIWORD(wp)
+#define GET_WM_CHARTOITEM_HWND(wp,lp) (HWND)(lp)
+#define GET_WM_CHARTOITEM_MPS(ch,pos,hwnd) (WPARAM)MAKELONG((pos),(ch)),(LPARAM)(hwnd)
+
+#define GET_WM_COMMAND_ID(wp,lp) LOWORD(wp)
+#define GET_WM_COMMAND_HWND(wp,lp) (HWND)(lp)
+#define GET_WM_COMMAND_CMD(wp,lp) HIWORD(wp)
+#define GET_WM_COMMAND_MPS(id,hwnd,cmd) (WPARAM)MAKELONG(id,cmd),(LPARAM)(hwnd)
+
+#define WM_CTLCOLOR 0x0019
+
+#define GET_WM_CTLCOLOR_HDC(wp,lp,msg) (HDC)(wp)
+#define GET_WM_CTLCOLOR_HWND(wp,lp,msg) (HWND)(lp)
+#define GET_WM_CTLCOLOR_TYPE(wp,lp,msg) (WORD)(msg - WM_CTLCOLORMSGBOX)
+#define GET_WM_CTLCOLOR_MSG(type) (WORD)(WM_CTLCOLORMSGBOX+(type))
+#define GET_WM_CTLCOLOR_MPS(hdc,hwnd,type) (WPARAM)(hdc),(LPARAM)(hwnd)
+
+#define GET_WM_MENUSELECT_CMD(wp,lp) LOWORD(wp)
+#define GET_WM_MENUSELECT_FLAGS(wp,lp) (UINT)(int)(short)HIWORD(wp)
+#define GET_WM_MENUSELECT_HMENU(wp,lp) (HMENU)(lp)
+#define GET_WM_MENUSELECT_MPS(cmd,f,hmenu) (WPARAM)MAKELONG(cmd,f),(LPARAM)(hmenu)
+
+#define GET_WM_MDIACTIVATE_FACTIVATE(hwnd,wp,lp) (lp==(LPARAM)hwnd)
+#define GET_WM_MDIACTIVATE_HWNDDEACT(wp,lp) (HWND)(wp)
+#define GET_WM_MDIACTIVATE_HWNDACTIVATE(wp,lp) (HWND)(lp)
+
+#define GET_WM_MDIACTIVATE_MPS(f,hwndD,hwndA) (WPARAM)(hwndA),0
+
+#define GET_WM_MDISETMENU_MPS(hmenuF,hmenuW) (WPARAM)hmenuF,(LPARAM)hmenuW
+
+#define GET_WM_MENUCHAR_CHAR(wp,lp) (TCHAR)LOWORD(wp)
+#define GET_WM_MENUCHAR_HMENU(wp,lp) (HMENU)(lp)
+#define GET_WM_MENUCHAR_FMENU(wp,lp) (WINBOOL)HIWORD(wp)
+#define GET_WM_MENUCHAR_MPS(ch,hmenu,f) (WPARAM)MAKELONG(ch,f),(LPARAM)(hmenu)
+
+#define GET_WM_PARENTNOTIFY_MSG(wp,lp) LOWORD(wp)
+#define GET_WM_PARENTNOTIFY_ID(wp,lp) HIWORD(wp)
+#define GET_WM_PARENTNOTIFY_HWNDCHILD(wp,lp) (HWND)(lp)
+#define GET_WM_PARENTNOTIFY_X(wp,lp) (int)(short)LOWORD(lp)
+#define GET_WM_PARENTNOTIFY_Y(wp,lp) (int)(short)HIWORD(lp)
+#define GET_WM_PARENTNOTIFY_MPS(msg,id,hwnd) (WPARAM)MAKELONG(id,msg),(LPARAM)(hwnd)
+#define GET_WM_PARENTNOTIFY2_MPS(msg,x,y) (WPARAM)MAKELONG(0,msg),MAKELONG(x,y)
+
+#define GET_WM_VKEYTOITEM_CODE(wp,lp) (int)(short)LOWORD(wp)
+#define GET_WM_VKEYTOITEM_ITEM(wp,lp) HIWORD(wp)
+#define GET_WM_VKEYTOITEM_HWND(wp,lp) (HWND)(lp)
+#define GET_WM_VKEYTOITEM_MPS(code,item,hwnd) (WPARAM)MAKELONG(item,code),(LPARAM)(hwnd)
+
+#define GET_EM_SETSEL_START(wp,lp) (INT)(wp)
+#define GET_EM_SETSEL_END(wp,lp) (lp)
+#define GET_EM_SETSEL_MPS(iStart,iEnd) (WPARAM)(iStart),(LPARAM)(iEnd)
+
+#define GET_EM_LINESCROLL_MPS(vert,horz) (WPARAM)horz,(LPARAM)vert
+
+#define GET_WM_CHANGECBCHAIN_HWNDNEXT(wp,lp) (HWND)(lp)
+
+#define GET_WM_HSCROLL_CODE(wp,lp) LOWORD(wp)
+#define GET_WM_HSCROLL_POS(wp,lp) HIWORD(wp)
+#define GET_WM_HSCROLL_HWND(wp,lp) (HWND)(lp)
+#define GET_WM_HSCROLL_MPS(code,pos,hwnd) (WPARAM)MAKELONG(code,pos),(LPARAM)(hwnd)
+
+#define GET_WM_VSCROLL_CODE(wp,lp) LOWORD(wp)
+#define GET_WM_VSCROLL_POS(wp,lp) HIWORD(wp)
+#define GET_WM_VSCROLL_HWND(wp,lp) (HWND)(lp)
+#define GET_WM_VSCROLL_MPS(code,pos,hwnd) (WPARAM)MAKELONG(code,pos),(LPARAM)(hwnd)
+
+#define _ncalloc calloc
+#define _nexpand _expand
+#define _ffree free
+#define _fmalloc malloc
+#define _fmemccpy _memccpy
+#define _fmemchr memchr
+#define _fmemcmp memcmp
+#define _fmemcpy memcpy
+#define _fmemicmp _memicmp
+#define _fmemmove memmove
+#define _fmemset memset
+#define _fmsize _msize
+#define _frealloc realloc
+#define _fstrcat strcat
+#define _fstrchr strchr
+#define _fstrcmp strcmp
+#define _fstrcpy strcpy
+#define _fstrcspn strcspn
+#define _fstrdup _strdup
+#define _fstricmp _stricmp
+#define _fstrlen strlen
+#define _fstrlwr _strlwr
+#define _fstrncat strncat
+#define _fstrncmp strncmp
+#define _fstrncpy strncpy
+#define _fstrnicmp _strnicmp
+#define _fstrnset _strnset
+#define _fstrpbrk strpbrk
+#define _fstrrchr strrchr
+#define _fstrrev _strrev
+#define _fstrset _strset
+#define _fstrspn strspn
+#define _fstrstr strstr
+#define _fstrtok strtok
+#define _fstrupr _strupr
+#define _nfree free
+#define _nmalloc malloc
+#define _nmsize _msize
+#define _nrealloc realloc
+#define _nstrdup _strdup
+#define hmemcpy MoveMemory
+
+#ifndef DECLARE_HANDLE32
+#define DECLARE_HANDLE32 DECLARE_HANDLE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
Adds some headers ported from mingw, these allows Sokol (and therefore ui apps) to compile.