### PR TITLE
kernel32: add symbols for SRWLocks

### DIFF
--- a/lib/kernel32.def
+++ b/lib/kernel32.def
@@ -1,6 +1,8 @@
 LIBRARY kernel32.dll
 
 EXPORTS
+AcquireSRWLockExclusive
+AcquireSRWLockShared
 AddAtomA
 AddAtomW
 AddVectoredExceptionHandler
@@ -421,6 +423,7 @@ HeapWalk
 InitAtomTable
 InitializeCriticalSection
 InitializeCriticalSectionAndSpinCount
+InitializeSRWLock
 InterlockedCompareExchange
 InterlockedDecrement
 InterlockedExchange
@@ -546,6 +549,8 @@ RegisterSysMsgHandler
 ReinitializeCriticalSection
 ReleaseMutex
 ReleaseSemaphore
+ReleaseSRWLockExclusive
+ReleaseSRWLockShared
 RemoveDirectoryA
 RemoveDirectoryW
 RequestDeviceWakeup


### PR DESCRIPTION
In order to implement shared concurrency with separate read/write locks these symbols are needed to compile with tcc under Windows. See: [my branch](https://github.com/UweKrueger/v/tree/rwshared_rwlock).